### PR TITLE
[UPDATE] FIX JwtRequest 로인한 응답이 없지만 200인 에러 해결

### DIFF
--- a/src/main/java/com/server/EZY/security/JwtRequestFilter.java
+++ b/src/main/java/com/server/EZY/security/JwtRequestFilter.java
@@ -18,6 +18,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
+        filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
원인: filter에서 filterChain.doFilter(request, response);를 사용하지 않아 필터단에서 요청과 응답이 멈춰버림