### PR TITLE
[FIX] jwt error fix

### DIFF
--- a/src/main/java/com/server/EZY/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/EZY/service/RefreshTokenServiceImpl.java
@@ -37,9 +37,10 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         String nickname = jwtTokenProvider.getUsername(accessToken);
 
         if (redisUtil.getData(nickname).equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)) {
-
+            redisUtil.deleteData(nickname);//refreshToken이 저장되어있는 레디스 초기화 후
             newAccessToken = jwtTokenProvider.createToken(nickname, roles);
             newRefreshToken = jwtTokenProvider.createRefreshToken();
+            redisUtil.setDataExpire(nickname, newRefreshToken, 360000 * 1000l* 24 * 180); //새 refreshToken을 다시 저장
             map.put("nickname", nickname);
             map.put("NewAccessToken", "Bearer " + newAccessToken); // NewAccessToken 반환
             map.put("NewRefreshToken", "Bearer " + newRefreshToken); // NewRefreshToken 반환


### PR DESCRIPTION
refreshToken과 accessToken을 이용해서 토큰들을 재발급 받고 
재발급 받은 토큰들로 다시 재발급을 받으려하자 `null`이 반환되는것을 확인하였습니다.
알고보니 토큰을 재발급 받을 때 key가 nickname인 값의 redis를 비우지 않았으며 새 값도 지정해주지 않아서 생긴 오류였습니다. 😅
한마디로 오류 고쳤습니다..!! 