### PR TITLE
Feature/personal plan logic

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface PlanRepositoryCustom {
     List<PlanEntity> findAllPersonalPlanByUserEntity (UserEntity userEntity);
-    PlanEntity findByPersonalPlanByUserEntityAndPlanIdx (UserEntity userEntity, Long personalPlanId);
+    PlanEntity findThisPlanByUserEntityAndPlanIdx (UserEntity userEntity, Long personalPlanId);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface PlanRepositoryCustom {
     List<PlanEntity> findAllPersonalPlanByUserEntity (UserEntity userEntity);
-    PlanEntity findByPersonalPlanByUserEntityAndPlanIdx (UserEntity userEntity, Long planId);
+    PlanEntity findByPersonalPlanByUserEntityAndPlanIdx (UserEntity userEntity, Long personalPlanId);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryCustom.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface PlanRepositoryCustom {
     List<PlanEntity> findAllPersonalPlanByUserEntity (UserEntity userEntity);
+    PlanEntity findByPersonalPlanByUserEntityAndPlanIdx (UserEntity userEntity, Long planId);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
@@ -25,6 +25,12 @@ public class PlanRepositoryImpl implements PlanRepositoryCustom{
 
     @Override
     public PlanEntity findByPersonalPlanByUserEntityAndPlanIdx(UserEntity userEntity, Long planId) {
-        return null;
+        return queryFactory
+                .selectFrom(planEntity)
+                .where(
+                        planEntity.userEntity.eq(userEntity),
+                        planEntity.personalPlanEntity.personalPlanIdx.eq(planId),
+                        planEntity.planDType.eq(PlanDType.PERSONAL_PLAN)
+                ).fetchOne();
     }
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
@@ -22,4 +22,9 @@ public class PlanRepositoryImpl implements PlanRepositoryCustom{
                         planEntity.planDType.eq(PlanDType.PERSONAL_PLAN)
                 ).fetch();
     }
+
+    @Override
+    public PlanEntity findByPersonalPlanByUserEntityAndPlanIdx(UserEntity userEntity, Long planId) {
+        return null;
+    }
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PlanRepositoryImpl.java
@@ -24,7 +24,7 @@ public class PlanRepositoryImpl implements PlanRepositoryCustom{
     }
 
     @Override
-    public PlanEntity findByPersonalPlanByUserEntityAndPlanIdx(UserEntity userEntity, Long planId) {
+    public PlanEntity findThisPlanByUserEntityAndPlanIdx(UserEntity userEntity, Long planId) {
         return queryFactory
                 .selectFrom(planEntity)
                 .where(

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -79,7 +79,7 @@ public class PersonalPlanService {
      * @author 전지환
      */
     public PlanEntity getThisPersonalPlan(UserEntity userEntity, Long personalPlanId){
-        return planRepository.findByPersonalPlanByUserEntityAndPlanIdx(userEntity, personalPlanId);
+        return planRepository.findThisPlanByUserEntityAndPlanIdx(userEntity, personalPlanId);
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -62,7 +62,7 @@ public class PersonalPlanService {
     }
 
     /**
-     * 이 메서드는 엔티티를 넘겨주면 그 엔티티에 해당하는 모든 개인 일정을 조회합니다.
+     * 이 메서드는 유저 엔티티를 넘겨주면 그 유저에 해당하는 모든 개인 일정을 조회합니다.
      * @param userEntity
      * @return PlanEntity
      * @author 전지환
@@ -71,8 +71,15 @@ public class PersonalPlanService {
         return planRepository.findAllPersonalPlanByUserEntity(userEntity);
     }
 
-    public PlanEntity getThisPersonalPlan(Long planId){
-
+    /**
+     * 이 메서드는 유저 엔티티와 PersonalPlanId 를 넘겨주면 해당 PlanEntity 를 조회합니다.
+     * @param userEntity
+     * @param personalPlanId
+     * @return PlanEntity
+     * @author 전지환
+     */
+    public PlanEntity getThisPersonalPlan(UserEntity userEntity, Long personalPlanId){
+        return planRepository.findByPersonalPlanByUserEntityAndPlanIdx(userEntity, personalPlanId);
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -2,7 +2,6 @@ package com.server.EZY.model.plan.personal.service;
 
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import com.server.EZY.model.plan.personal.dto.PersonalPlanDto;
-import com.server.EZY.model.plan.personal.dto.PersonalPlanUpdateDto;
 import com.server.EZY.model.plan.personal.repository.PersonalPlanRepository;
 import com.server.EZY.model.plan.plan.PlanEntity;
 import com.server.EZY.model.plan.plan.repository.PlanRepository;
@@ -70,6 +69,10 @@ public class PersonalPlanService {
      */
     public List<PlanEntity> getAllMyPersonalPlan(UserEntity userEntity){
         return planRepository.findAllPersonalPlanByUserEntity(userEntity);
+    }
+
+    public PlanEntity getThisPersonalPlan(Long planId){
+
     }
 
     /**


### PR DESCRIPTION
### 해당 `PersonalPlanIdx` 를 넘겨주어 `PlanEntity`를 조회하는 로직 작성
1. `Custom.interface` `impl.class` Querydsl 작성 완료.
2. `TDD` 성공, 수행

### 이건 같이 생각해 봐요!

아직 api가 정확히 확정이 안된 것 같아 초안으로 `PlanEntity` 자체를 반환합니다..
추후에 Dto로 바꾸어 return 하는건 쉽습니다! 

현재 PR 날린 전체 조회, 이 일정(하나) 조회 두 메서드에 대해.. 
어떤 data를 response 하는게 좋을지 comment 및 의사결정 부탁드립니다.

### 코드리뷰 부탁드립니다
* `Custom.interface`의 querydsl 메서드 네이밍
* TestCode 검증결과 및 개선사항 요청해주세요!
