### PR TITLE
[FIX] #55번 이슈 해결

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/plan/PlanEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/plan/PlanEntity.java
@@ -32,7 +32,7 @@ public class PlanEntity {
 
     //PlanEntity가  저장, 병합, 삭제가 발생될때 PersonalPlanEntity에 전의됩니다.
     @OneToOne(fetch = LAZY, cascade = {PERSIST, MERGE, REMOVE})
-    @JoinColumn(name = "PersonalPlanId")
+    @JoinColumn(name = "PersonalPlanId", unique = true)
     private PersonalPlanEntity personalPlanEntity;
 
     //PlanEntity가 저장, 병합이 발생될때 TeamPlanEntity에 전의됩니다.


### PR DESCRIPTION
`PlanEntity`에 `PersoanlPlanEntity personalPlanEntity` 필드에 UNIQUE 제약조건을 추가하여 #55 이슈를 수정했습니다.  

이제 `PlanEntity`와 `PersonalEntity`는 1 : 1 매핑이 확실하게 되었지만
`src.test.com.server.EZY.model.personal.repository.PlanRepositorySupportTest`에 `개인일정_모두_찾기()` 테스트가 실패합니다.
`Stream`으로 `PlanEntity` 생성하실때 `PersonalPlanEntity`를 `new` 연산자를 활용하여 객체를 각각 생성하셔서 진행하시길 바랍니다.
@Johnjihwan

예시
```java
        List<PlanEntity> planEntities = Stream.generate(
                () -> new PlanEntity(
                        new PersonalPlanEntity(),
                        userEntity_t,
                        categories
                )
        ).limit(12).collect(Collectors.toList());