### PR TITLE
[UPDATE] currentUser Util

### DIFF
--- a/src/main/java/com/server/EZY/model/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/user/service/UserServiceImpl.java
@@ -124,21 +124,4 @@ public class UserServiceImpl implements UserService {
         }
         return withdrawalDto.getNickname() + "회원 회원탈퇴완료";
     }
-
-
-    /**
-     * 현재 로그인 되어있는(인증되어있는) User의 nickname을 반환하는 메서드
-     * @return nickname
-     * @author 배태현
-     */
-    public static String getCurrentUserNickname() {
-        String nickname = null;
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if(principal instanceof UserDetails) {
-            nickname = ((UserDetails) principal).getUsername();
-        } else{
-            nickname = principal.toString();
-        }
-        return nickname;
-    }
 }

--- a/src/main/java/com/server/EZY/model/user/util/CurrentUser.java
+++ b/src/main/java/com/server/EZY/model/user/util/CurrentUser.java
@@ -1,0 +1,29 @@
+package com.server.EZY.model.user.util;
+
+import com.server.EZY.model.user.UserEntity;
+import com.server.EZY.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CurrentUser {
+
+    /**
+     * 현재 로그인 되어있는(인증되어있는) User의 nickname을 반환하는 메서드
+     * @return nickname
+     * @author 배태현
+     */
+    public static String getCurrentUserNickname() {
+        String nickname = null;
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if(principal instanceof UserDetails) {
+            nickname = ((UserDetails) principal).getUsername();
+        } else{
+            nickname = principal.toString();
+        }
+        return nickname;
+    }
+}

--- a/src/main/java/com/server/EZY/model/user/util/CurrentUserUtil.java
+++ b/src/main/java/com/server/EZY/model/user/util/CurrentUserUtil.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CurrentUser {
+public class CurrentUserUtil {
 
     /**
      * 현재 로그인 되어있는(인증되어있는) User의 nickname을 반환하는 메서드

--- a/src/test/java/com/server/EZY/model/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/EZY/model/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.server.EZY.model.user.controller.UserController;
 import com.server.EZY.model.user.dto.*;
 import com.server.EZY.model.user.enumType.Role;
 import com.server.EZY.model.user.repository.UserRepository;
+import com.server.EZY.model.user.util.CurrentUser;
 import com.server.EZY.security.jwt.JwtTokenProvider;
 import com.server.EZY.util.RedisUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -36,13 +37,13 @@ public class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
     @Autowired
-    private UserServiceImpl userServiceImpl;
-    @Autowired
     private RedisUtil redisUtil;
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
     @Autowired
     private UserService userService;
+    @Autowired
+    private CurrentUser currentUser;
 
     @Test
     @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
@@ -69,7 +70,7 @@ public class UserServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = userServiceImpl.getCurrentUserNickname();
+        String currentUserNickname = currentUser.getCurrentUserNickname();
         assertEquals("배태현", currentUserNickname);
     }
 
@@ -194,7 +195,7 @@ public class UserServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = userServiceImpl.getCurrentUserNickname();
+        String currentUserNickname = currentUser.getCurrentUserNickname();
         assertEquals("배태현", currentUserNickname);
         UserEntity loginUser = userRepository.findByNickname(currentUserNickname);
         return loginUser;

--- a/src/test/java/com/server/EZY/model/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/EZY/model/user/service/UserServiceTest.java
@@ -5,7 +5,7 @@ import com.server.EZY.model.user.controller.UserController;
 import com.server.EZY.model.user.dto.*;
 import com.server.EZY.model.user.enumType.Role;
 import com.server.EZY.model.user.repository.UserRepository;
-import com.server.EZY.model.user.util.CurrentUser;
+import com.server.EZY.model.user.util.CurrentUserUtil;
 import com.server.EZY.security.jwt.JwtTokenProvider;
 import com.server.EZY.util.RedisUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -42,8 +42,6 @@ public class UserServiceTest {
     private JwtTokenProvider jwtTokenProvider;
     @Autowired
     private UserService userService;
-    @Autowired
-    private CurrentUser currentUser;
 
     @Test
     @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
@@ -70,7 +68,7 @@ public class UserServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = currentUser.getCurrentUserNickname();
+        String currentUserNickname = CurrentUserUtil.getCurrentUserNickname();
         assertEquals("배태현", currentUserNickname);
     }
 
@@ -195,7 +193,7 @@ public class UserServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = currentUser.getCurrentUserNickname();
+        String currentUserNickname = CurrentUserUtil.getCurrentUserNickname();
         assertEquals("배태현", currentUserNickname);
         UserEntity loginUser = userRepository.findByNickname(currentUserNickname);
         return loginUser;


### PR DESCRIPTION
`UserServiceImpl`에 있던 `getCurrentUserNickname()`를 `model.user.util` package를 만들어 옮겼습니다.
Util클래스를 생성한대로 Test코드도 바꿨지만 `PersonalPlanService`에서는 바꾸지 않아서 오류가 납니다.
그래서 아직 Test코드를 실행해보지 못했습니다!
`PersonalPlanService` 오류부분 @Johnjihwan 제가 Util클래스 만든부분 맞춰서 해결 부탁드립니다!

<img width="1150" alt="스크린샷 2021-06-30 오전 9 34 14" src="https://user-images.githubusercontent.com/69895394/123890987-26d75c00-d993-11eb-86b5-cfe19a87f949.png">

Util클래스 나눈 점과 다른 더 좋은 해결방안이 있으면 수정제안 부탁드립니다!

추가) `getCurrentUserNickname()`에서 nickname을 return하지않고 `findByNickname`을 사용하여 `UserEntity`를 반환하는 방법을 시도해보았지만 **static** 메서드라 불가능했습니다..🥲