### PR TITLE
[FIX] HeadOfPlanEntity의 생성자의 인자의 위치가 변경됨으로써 컴파일 오류 해결

### DIFF
--- a/src/test/java/com/server/EZY/model/plan/HeadOfPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/HeadOfPlanEntityTest.java
@@ -73,8 +73,8 @@ class HeadOfPlanEntityTest {
 
         List<String> categories = Collections.singletonList("공부");
         HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(
-                personalPlanEntity
-                ,userEntity
+                userEntity
+                , personalPlanEntity
                 ,categories
         );
 
@@ -107,16 +107,16 @@ class HeadOfPlanEntityTest {
         final List<String> CATEGORIES = Collections.singletonList(RandomString.make(10));
         // When
         Throwable planConstructException1 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(nullPersonalPlanEntity, userEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(userEntity, nullPersonalPlanEntity, CATEGORIES)
         );
         Throwable planConstructException2 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(personalPlanEntity, nullUserEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(nullUserEntity, personalPlanEntity, CATEGORIES)
         );
         Throwable planConstructException3 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(nullPersonalPlanEntity, nullUserEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(nullUserEntity, nullPersonalPlanEntity, CATEGORIES)
         );
         Throwable planConstructException4 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(personalPlanEntity, userEntity, null)
+                , () -> new HeadOfPlanEntity(userEntity, personalPlanEntity, null)
         );
 
         // Then
@@ -133,7 +133,7 @@ class HeadOfPlanEntityTest {
         TeamPlanEntity teamPlanEntity = teamPlanEntityInit(userAEntity);
 
         List<String> categories = Collections.singletonList("공부");
-        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(teamPlanEntity, userAEntity, categories);
+        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(userAEntity, teamPlanEntity, categories);
 
         // When
         HeadOfPlanEntity savedHeadOfPlanEntity = headOfPlanRepository.save(headOfPlanEntity);
@@ -167,16 +167,16 @@ class HeadOfPlanEntityTest {
 
         // When
         IllegalArgumentException planConstructException1 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(nullTeamPlanEntity, userEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(userEntity, nullTeamPlanEntity, CATEGORIES)
         );
         IllegalArgumentException planConstructException2 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(teamPlanEntity, nullUserEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(nullUserEntity, teamPlanEntity, CATEGORIES)
         );
         IllegalArgumentException planConstructException3 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(nullTeamPlanEntity, nullUserEntity, CATEGORIES)
+                , () -> new HeadOfPlanEntity(nullUserEntity, nullTeamPlanEntity, CATEGORIES)
         );
         IllegalArgumentException planConstructException4 = assertThrows(IllegalArgumentException.class
-                , () -> new HeadOfPlanEntity(teamPlanEntity, userEntity, null)
+                , () -> new HeadOfPlanEntity(userEntity, teamPlanEntity, null)
         );
 
         // Then

--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalHeadOfPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalHeadOfPlanEntityTest.java
@@ -81,8 +81,8 @@ class PersonalHeadOfPlanEntityTest {
 
         List<String> categories = Collections.singletonList("공부");
         HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(
-                personalPlanEntity
-                ,userEntity
+                userEntity
+                ,personalPlanEntity
                 ,categories
         );
 
@@ -110,14 +110,14 @@ class PersonalHeadOfPlanEntityTest {
         PersonalPlanEntity userAPersonalPlan1 = personalPlanEntityInit();
         PersonalPlanEntity userAPersonalPlan2 = personalPlanEntityInit();
         List<HeadOfPlanEntity> userAPlans = new ArrayList<>(Arrays.asList(
-                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userAPersonalPlan1, userA), new HeadOfPlanEntity(userAPersonalPlan2, userA)})
+                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userA, userAPersonalPlan1), new HeadOfPlanEntity(userA, userAPersonalPlan2)})
         );
         headOfPlanRepository.saveAll(userAPlans);
 
         UserEntity userB = userEntityInit();
         TeamPlanEntity userABTeamPlan = teamPlanEntityInit(userB);
         List<HeadOfPlanEntity> ABTeamPlan = new ArrayList<>(Arrays.asList(
-                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userABTeamPlan, userA), new HeadOfPlanEntity(userABTeamPlan, userB)}
+                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userA, userABTeamPlan), new HeadOfPlanEntity(userB, userABTeamPlan)}
         ));
         headOfPlanRepository.saveAll(ABTeamPlan);
 
@@ -143,7 +143,7 @@ class PersonalHeadOfPlanEntityTest {
         // Given
         UserEntity userEntity = userEntityInit();
         PersonalPlanEntity personalPlanEntity = personalPlanEntityInit();
-        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(personalPlanEntity, userEntity);
+        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(userEntity, personalPlanEntity);
         HeadOfPlanEntity savedHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(headOfPlanEntity);
         em.clear();
 
@@ -177,7 +177,7 @@ class PersonalHeadOfPlanEntityTest {
         // Given
         UserEntity userEntity = userEntityInit();
         PersonalPlanEntity personalPlanEntity = personalPlanEntityInit();
-        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(personalPlanEntity, userEntity);
+        HeadOfPlanEntity headOfPlanEntity = new HeadOfPlanEntity(userEntity, personalPlanEntity);
         HeadOfPlanEntity savedHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(headOfPlanEntity);
         em.clear();
 

--- a/src/test/java/com/server/EZY/model/plan/personal/repository/HeadOfPlanRepositorySupportTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/repository/HeadOfPlanRepositorySupportTest.java
@@ -131,16 +131,16 @@ class HeadOfPlanRepositorySupportTest {
         // 태현이의 Plan을 12개 추가합니다.
         List<HeadOfPlanEntity> planEntities = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        personalPlanEntityInit(),
                         userEntity_t,
+                        personalPlanEntityInit(),
                         categories
                 )
         ).limit(12).collect(Collectors.toList());
         // 지환이의 Plan을 16개 추가합니다.
         List<HeadOfPlanEntity> planEntities_2 = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        personalPlanEntityInit(),
                         userEntity_j,
+                        personalPlanEntityInit(),
                         categories
                 )
         ).limit(16).collect(Collectors.toList());
@@ -179,16 +179,16 @@ class HeadOfPlanRepositorySupportTest {
         // BeforeEach 짱짱짱 Plan을 12개 추가합니다.
         List<HeadOfPlanEntity> planEntities = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        personalPlanEntityInit(),
                         beforeSavedUser,
+                        personalPlanEntityInit(),
                         categories
                 )
         ).limit(12).collect(Collectors.toList());
         // 지환이의 Plan을 16개 추가합니다.
         List<HeadOfPlanEntity> planEntities_2 = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        personalPlanEntityInit(),
                         userEntity_j,
+                        personalPlanEntityInit(),
                         categories
                 )
         ).limit(16).collect(Collectors.toList());
@@ -227,14 +227,14 @@ class HeadOfPlanRepositorySupportTest {
         List<String> categories_t = Collections.singletonList("태현이와 데이트");
 
         HeadOfPlanEntity headOfPlanEntity_j = new HeadOfPlanEntity(
-                personalPlanEntityInit(),
                 beforeSavedUser,
+                personalPlanEntityInit(),
                 categories_j
         );
 
         HeadOfPlanEntity headOfPlanEntity_t = new HeadOfPlanEntity(
-                personalPlanEntityInit(),
                 userEntity_t,
+                personalPlanEntityInit(),
                 categories_t
         );
 
@@ -270,8 +270,8 @@ class HeadOfPlanRepositorySupportTest {
         List<String> categories_j = Collections.singletonList("지환이와 데이트");
 
         HeadOfPlanEntity headOfPlanEntity_j = new HeadOfPlanEntity(
-                personalPlanEntityInit(),
                 userEntity_j,
+                personalPlanEntityInit(),
                 categories_j
         );
 

--- a/src/test/java/com/server/EZY/model/plan/team/TeamHeadOfPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/team/TeamHeadOfPlanEntityTest.java
@@ -78,7 +78,7 @@ class TeamHeadOfPlanEntityTest {
         TeamPlanEntity userATeamPlan = teamPlanEntityInit(userA);
         PersonalPlanEntity userAPersonalPlan = personalPlanEntityInit();
         List<HeadOfPlanEntity> userAPlans = new ArrayList<>(Arrays.asList(
-                new HeadOfPlanEntity[]{new HeadOfPlanEntity(userAPersonalPlan, userA), new HeadOfPlanEntity(userATeamPlan, userA)})
+                new HeadOfPlanEntity[]{new HeadOfPlanEntity(userA, userAPersonalPlan), new HeadOfPlanEntity(userA, userATeamPlan)})
         );
         headOfPlanRepository.saveAll(userAPlans);
 
@@ -86,7 +86,7 @@ class TeamHeadOfPlanEntityTest {
         UserEntity userB = userEntityInit();
         TeamPlanEntity userABTeamPlan = teamPlanEntityInit(userB);
         List<HeadOfPlanEntity> ABTeamPlan = new ArrayList<>(Arrays.asList(
-                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userABTeamPlan, userA), new HeadOfPlanEntity(userABTeamPlan, userB)}
+                new HeadOfPlanEntity[] {new HeadOfPlanEntity(userA, userABTeamPlan), new HeadOfPlanEntity(userB, userABTeamPlan)}
         ));
         headOfPlanRepository.saveAll(ABTeamPlan);
 
@@ -124,7 +124,7 @@ class TeamHeadOfPlanEntityTest {
         // Given
         UserEntity userEntityTeamLeader = userEntityInit();
         TeamPlanEntity beforeUpdatedTeamPlanEntity = teamPlanEntityInit(userEntityTeamLeader);
-        HeadOfPlanEntity savedTeamPlan = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(beforeUpdatedTeamPlanEntity, userEntityTeamLeader));
+        HeadOfPlanEntity savedTeamPlan = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(userEntityTeamLeader, beforeUpdatedTeamPlanEntity));
         em.clear();
 
         // When
@@ -155,8 +155,8 @@ class TeamHeadOfPlanEntityTest {
         UserEntity teamLeader = userEntityInit();
         UserEntity teamMemberA = userEntityInit();
         TeamPlanEntity beforeUpdatedTeamPlanEntity = teamPlanEntityInit(teamLeader);
-        headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(beforeUpdatedTeamPlanEntity, teamLeader));
-        HeadOfPlanEntity savedMemberATeamHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(beforeUpdatedTeamPlanEntity, teamMemberA));
+        headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(teamLeader, beforeUpdatedTeamPlanEntity));
+        HeadOfPlanEntity savedMemberATeamHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(teamMemberA, beforeUpdatedTeamPlanEntity));
         em.clear();
 
         // When
@@ -191,8 +191,8 @@ class TeamHeadOfPlanEntityTest {
         UserEntity teamLeader = userEntityInit();
         UserEntity teamMemberA = userEntityInit();
         TeamPlanEntity beforeUpdatedTeamPlanEntity = teamPlanEntityInit(teamLeader);
-        headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(beforeUpdatedTeamPlanEntity, teamLeader));
-        HeadOfPlanEntity savedMemberATeamHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(beforeUpdatedTeamPlanEntity, teamMemberA));
+        headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(teamLeader, beforeUpdatedTeamPlanEntity));
+        HeadOfPlanEntity savedMemberATeamHeadOfPlanEntity = headOfPlanRepository.saveAndFlush(new HeadOfPlanEntity(teamMemberA, beforeUpdatedTeamPlanEntity));
         em.clear();
 
         // When

--- a/src/test/java/com/server/EZY/model/plan/team/service/TeamPlanServiceTest.java
+++ b/src/test/java/com/server/EZY/model/plan/team/service/TeamPlanServiceTest.java
@@ -137,15 +137,15 @@ class TeamPlanServiceTest {
         // 내가 찾을 team_plan
         List<HeadOfPlanEntity> teamPlanEntity = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        teamPlanEntityInit(leader),
-                        leader
-                                                )
+                        leader,
+                        teamPlanEntityInit(leader)
+                                                  )
         ).limit(10).collect(Collectors.toList());
         // 다른 사람의 team_plan
         List<HeadOfPlanEntity> a_teamPlanEntity = Stream.generate(
                 () -> new HeadOfPlanEntity(
-                        teamPlanEntityInit(anotherUser),
-                        anotherUser
+                        anotherUser,
+                        teamPlanEntityInit(anotherUser)
                 )
         ).limit(12).collect(Collectors.toList());
 


### PR DESCRIPTION
### 한 일
- `HeadOfEntity` 생성자 인자의 위치가 바뀜으로써 `test` 코드에 `compile error`가 나는 현상을 해결했습니다.

### Test 도중 error
- `gradle clean build `도중 테스트 단계에서 queryDsl를 사용하는 class에서  `Failed to load ApplicationContext` 에러가 납니다. 확인해주세요