### PR TITLE
gradle clean build시 warning 제거

### DIFF
--- a/src/main/java/com/server/EZY/exception/ExceptionAdviceImpl.java
+++ b/src/main/java/com/server/EZY/exception/ExceptionAdviceImpl.java
@@ -44,7 +44,7 @@ public class ExceptionAdviceImpl implements ExceptionAdvice{
     // 알수없는 에러
     @Override
     public CommonResult defaultException(Exception ex){
-        log.info("=== UnknownException 발생 === \n{}", ex.getStackTrace());
+        log.error("=== 알 수 없는 애러 발생 ===", ex);
         CommonResult exceptionResponseObj = getExceptionResponseObj(DEFAULT_EXCEPTION);
         return exceptionResponseObj;
     }

--- a/src/main/java/com/server/EZY/exception/customError/CustomExceptionController.java
+++ b/src/main/java/com/server/EZY/exception/customError/CustomExceptionController.java
@@ -1,6 +1,7 @@
 package com.server.EZY.exception.customError;
 
 import com.server.EZY.response.result.CommonResult;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/exception")
 public class CustomExceptionController {
 
+    @GetMapping
     public CommonResult exception() throws Exception {
         throw new Exception();
     }


### PR DESCRIPTION
### 한 일
- 다음과 같이 `ExceptionAdviceImpl` 에서 나타나는 warning을 제거 했습니다.
  <img width="1950" alt="스크린샷 2021-07-09 11 42 47" src="https://user-images.githubusercontent.com/62932968/125016209-e753f280-e0ab-11eb-9375-585387740411.png">
- `ExceptionAdviceImpl` 에서 알 수 없는 에러를 `catch`시 `Error`의 `StackTrace`가 `logging`을 통해 출력되도록 로직을 변경했습니다.

### gradle clean build 결과
![image](https://user-images.githubusercontent.com/62932968/125016547-80830900-e0ac-11eb-9e09-dc6b54e81f6e.png)

![image](https://user-images.githubusercontent.com/62932968/125016576-8b3d9e00-e0ac-11eb-8b7b-c48fe73c12a6.png)
