### PR TITLE
Feature/response service test

### DIFF
--- a/src/main/java/com/server/EZY/response/ResponseService.java
+++ b/src/main/java/com/server/EZY/response/ResponseService.java
@@ -13,7 +13,7 @@ public class ResponseService {
 
     @Getter
     public enum CommonResponse{
-        SUCCESS(200, "성공하였습니다."),
+        SUCCESS(1, "성공하였습니다."),
         FAIL(-1, "실패하였습니다.");
 
         int code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,8 +47,7 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql : trace
-    com.server.EZY.model: debug
-    com.server.EZY.exception: debug
+    com.server.EZY: debug
 
 ### Security ###
 security:

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -1,13 +1,18 @@
 package com.server.EZY.response;
 
 import com.server.EZY.response.result.CommonResult;
+import com.server.EZY.response.result.ListResult;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
+@Slf4j
 @SpringBootTest
 class ResponseServiceTest {
 
@@ -51,5 +56,22 @@ class ResponseServiceTest {
         assertEquals(false, successResult.isSuccess());
         assertEquals(FAIL_MSG, successResult.getMassage());
         assertEquals(FAIL_CODE, successResult.getCode());
+    }
+
+    @Test @DisplayName("getListResult 테스트")
+    void getListResult_테스트(){
+        //Given
+        List<String> givenData = List.of(new String[]{"배태현, 전지환, 정시원"});
+
+        //When
+        ListResult<String> listResult = responseService.getListResult(givenData);
+
+        //Then
+        assertEquals(true, listResult.isSuccess());
+        assertEquals(SUCCESS_CODE, listResult.getCode());
+        assertEquals(SUCCESS_MSG, listResult.getMassage());
+        assertEquals(givenData, listResult.getList());
+
+        log.debug("ListResult = {}", listResult.getList());
     }
 }

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -41,4 +41,15 @@ class ResponseServiceTest {
         assertEquals(SUCCESS_MSG, successResult.getMassage());
         assertEquals(SUCCESS_CODE, successResult.getCode());
     }
+
+    @Test @DisplayName("getFailResult 테스트")
+    void getFailResult_테스트(){
+        // Given When
+        CommonResult successResult = responseService.getFailResult();
+
+        // Then
+        assertEquals(false, successResult.isSuccess());
+        assertEquals(FAIL_MSG, successResult.getMassage());
+        assertEquals(FAIL_CODE, successResult.getCode());
+    }
 }

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -2,6 +2,7 @@ package com.server.EZY.response;
 
 import com.server.EZY.response.result.CommonResult;
 import com.server.EZY.response.result.ListResult;
+import com.server.EZY.response.result.SingleResult;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,23 @@ class ResponseServiceTest {
         assertEquals(false, successResult.isSuccess());
         assertEquals(FAIL_MSG, successResult.getMassage());
         assertEquals(FAIL_CODE, successResult.getCode());
+    }
+
+    @Test @DisplayName("getSingleResult 테스트")
+    void getSingleResult_테스트(){
+        //Given
+        String givenData = "정시원";
+
+        //When
+        SingleResult<String> singleResult = responseService.getSingleResult(givenData);
+
+        //Then
+        assertEquals(true, singleResult.isSuccess());
+        assertEquals(SUCCESS_CODE, singleResult.getCode());
+        assertEquals(SUCCESS_MSG, singleResult.getMassage());
+        assertEquals(givenData, singleResult.getData());
+
+        log.debug("SingleResult = {}", singleResult.getData());
     }
 
     @Test @DisplayName("getListResult 테스트")

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -25,5 +25,9 @@ class ResponseServiceTest {
         assertEquals(1, SUCCESS_CODE);
     }
 
-
+    @Test @DisplayName("\"ResponseService.CommonResponse 실패시 message, code 검증")
+    void CommonResponse_실패_message_code_검증(){
+        assertEquals("실패하였습니다.", FAIL_MSG);
+        assertEquals(1, FAIL_CODE);
+    }
 }

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -30,4 +30,15 @@ class ResponseServiceTest {
         assertEquals("실패하였습니다.", FAIL_MSG);
         assertEquals(1, FAIL_CODE);
     }
+
+    @Test @DisplayName("getSuccessResult 테스트")
+    void getSuccessResult_테스트(){
+        // Given When
+        CommonResult successResult = responseService.getSuccessResult();
+
+        // Then
+        assertEquals(true, successResult.isSuccess());
+        assertEquals(SUCCESS_MSG, successResult.getMassage());
+        assertEquals(SUCCESS_CODE, successResult.getCode());
+    }
 }

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -28,7 +28,7 @@ class ResponseServiceTest {
     @Test @DisplayName("\"ResponseService.CommonResponse 실패시 message, code 검증")
     void CommonResponse_실패_message_code_검증(){
         assertEquals("실패하였습니다.", FAIL_MSG);
-        assertEquals(1, FAIL_CODE);
+        assertEquals(-1, FAIL_CODE);
     }
 
     @Test @DisplayName("getSuccessResult 테스트")

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -1,0 +1,29 @@
+package com.server.EZY.response;
+
+import com.server.EZY.response.result.CommonResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ResponseServiceTest {
+
+    @Autowired ResponseService responseService;
+
+    final String SUCCESS_MSG = ResponseService.CommonResponse.SUCCESS.massage;
+    final int SUCCESS_CODE = ResponseService.CommonResponse.SUCCESS.code;
+
+    final String FAIL_MSG = ResponseService.CommonResponse.FAIL.massage;
+    final int FAIL_CODE = ResponseService.CommonResponse.FAIL.code;
+
+    @Test @DisplayName("ResponseService.CommonResponse 성공시 message, code 검증")
+    void CommonResponse_성공_message_code_검증(){
+        assertEquals("성공하였습니다.", SUCCESS_MSG);
+        assertEquals(1, SUCCESS_CODE);
+    }
+
+
+}


### PR DESCRIPTION
### 한 일
- `ResponseService` 에 대한 테스트를 모두 완료했습니다.
- `ResponseService` 에 `CommonResponse` 에 `SUCCESS`의 `code`를 200에서 1로 변경했습니다.

### 테스트 결과
![image](https://user-images.githubusercontent.com/62932968/125028737-7fa9a180-e0c3-11eb-8a8b-0aa4db5340ad.png)
![image](https://user-images.githubusercontent.com/62932968/125028751-86381900-e0c3-11eb-9d5d-3944bf77b421.png)
