### PR TITLE
Feature/jpa auditing

### DIFF
--- a/src/main/java/com/server/EZY/EzyApplication.java
+++ b/src/main/java/com/server/EZY/EzyApplication.java
@@ -2,8 +2,10 @@ package com.server.EZY;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class EzyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/EZY/model/baseTime/BaseTimeEntity.java
+++ b/src/main/java/com/server/EZY/model/baseTime/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.server.EZY.model.baseTime;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass @EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate @Column(name = "create_date", updatable = false)
+    private LocalDateTime createdDate;
+
+    @CreatedDate @Column(name = "modified_date", updatable = false)
+    private LocalDateTime modifiedDate;
+}

--- a/src/test/java/com/server/EZY/EzyApplicationTests.java
+++ b/src/test/java/com/server/EZY/EzyApplicationTests.java
@@ -11,7 +11,6 @@ import java.util.Base64;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@EnableJpaAuditing
 class EzyApplicationTests {
 
 	@Value("${security.jwt.token.secret-key}")

--- a/src/test/java/com/server/EZY/EzyApplicationTests.java
+++ b/src/test/java/com/server/EZY/EzyApplicationTests.java
@@ -3,6 +3,7 @@ package com.server.EZY;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import javax.annotation.PostConstruct;
 import java.util.Base64;
@@ -10,6 +11,7 @@ import java.util.Base64;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@EnableJpaAuditing
 class EzyApplicationTests {
 
 	@Value("${security.jwt.token.secret-key}")


### PR DESCRIPTION
### 한 일
- JpaAuditing 활성화 했습니다.
- Entity의 시작시간 수정시간을 관리하는 `BaseTimeEntity`를 생성했습니다.

PersonalPlanEntity, UserEntity에 extends할 에정이므로 test코드를 작성하지 않았습니다.