### PR TITLE
Feature/entity redesign

### DIFF
--- a/src/main/java/com/server/EZY/model/baseTime/BaseTimeEntity.java
+++ b/src/main/java/com/server/EZY/model/baseTime/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package com.server.EZY.model.baseTime;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.Column;
@@ -13,9 +14,10 @@ import java.time.LocalDateTime;
 @MappedSuperclass @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
-    @CreatedDate @Column(name = "create_date", updatable = false)
+    @CreatedDate @Column(name = "create_date", updatable = false, nullable = false)
     private LocalDateTime createdDate;
 
-    @CreatedDate @Column(name = "modified_date", updatable = false)
+    @LastModifiedDate
+    @Column(name = "modified_date",  nullable = false)
     private LocalDateTime modifiedDate;
 }

--- a/src/main/java/com/server/EZY/model/member/MemberEntity.java
+++ b/src/main/java/com/server/EZY/model/member/MemberEntity.java
@@ -1,6 +1,6 @@
 package com.server.EZY.model.member;
 
-import com.server.EZY.model.member.enumType.Permission;
+import com.server.EZY.model.baseTime.BaseTimeEntity;
 import com.server.EZY.model.member.enumType.Role;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -21,24 +21,20 @@ import static javax.persistence.EnumType.*;
 @Entity @Table(name = "member")
 @Builder @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
-public class MemberEntity implements UserDetails {
+public class MemberEntity extends BaseTimeEntity implements UserDetails{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long userIdx;
 
-    @Column(name = "nickname", nullable = false, unique = true)
+    @Column(name = "username", nullable = false, unique = true)
     private String username;
 
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "phonenumber", nullable = false, unique = true)
+    @Column(name = "phone_number", nullable = false, unique = true)
     private String phoneNumber;
-
-    @Column(name = "Permission", nullable = false)
-    @Enumerated(value = STRING)
-    private Permission permission;
 
     @Enumerated(STRING) @Column(name = "role")
     @ElementCollection(fetch = FetchType.EAGER)
@@ -88,7 +84,7 @@ public class MemberEntity implements UserDetails {
         return true;
     }
 
-    public void updateNickname(String nickname) {
+    public void updateUsername(String nickname) {
         this.username = nickname != null ? nickname : this.username;
     }
 
@@ -101,11 +97,11 @@ public class MemberEntity implements UserDetails {
         if (this == o) return true;
         if (!(o instanceof MemberEntity)) return false;
         MemberEntity that = (MemberEntity) o;
-        return Objects.equals(getUserIdx(), that.getUserIdx()) && Objects.equals(getUsername(), that.getUsername()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getPhoneNumber(), that.getPhoneNumber()) && getPermission() == that.getPermission() && Objects.equals(getRoles(), that.getRoles());
+        return Objects.equals(getUserIdx(), that.getUserIdx()) && Objects.equals(getUsername(), that.getUsername()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getPhoneNumber(), that.getPhoneNumber()) && Objects.equals(getRoles(), that.getRoles());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUserIdx(), getUsername(), getPassword(), getPhoneNumber(), getPermission(), getRoles());
+        return Objects.hash(getUserIdx(), getUsername(), getPassword(), getPhoneNumber(), getRoles());
     }
 }

--- a/src/main/java/com/server/EZY/model/member/MemberEntity.java
+++ b/src/main/java/com/server/EZY/model/member/MemberEntity.java
@@ -84,8 +84,8 @@ public class MemberEntity extends BaseTimeEntity implements UserDetails{
         return true;
     }
 
-    public void updateUsername(String nickname) {
-        this.username = nickname != null ? nickname : this.username;
+    public void updateUsername(String username) {
+        this.username = username != null ? username : this.username;
     }
 
     public void updatePassword(String password) {

--- a/src/main/java/com/server/EZY/model/member/MemberEntity.java
+++ b/src/main/java/com/server/EZY/model/member/MemberEntity.java
@@ -18,34 +18,31 @@ import java.util.stream.Collectors;
 
 import static javax.persistence.EnumType.*;
 
-@Entity @Table(name = "User")
+@Entity @Table(name = "member")
 @Builder @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class MemberEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "member_id")
     private Long userIdx;
 
-    @Column(name = "NickName", nullable = false, unique = true)
-//    @Size(min = 1, max = 10)
-    private String nickname;
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String username;
 
-    @Column(name = "Password", nullable = false)
-//    @Size(min = 4, max = 10)
+    @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "PhoneNumber", nullable = false, unique = true)
-//    @Size(min = 11, max = 11)
+    @Column(name = "phonenumber", nullable = false, unique = true)
     private String phoneNumber;
 
     @Column(name = "Permission", nullable = false)
     @Enumerated(value = STRING)
     private Permission permission;
 
-    @Enumerated(STRING) @Column(name = "Role")
+    @Enumerated(STRING) @Column(name = "role")
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "Role", joinColumns = @JoinColumn(name = "UserIdx"))
+    @CollectionTable(name = "role", joinColumns = @JoinColumn(name = "user_id"))
     @Builder.Default
     private List<Role> roles = new ArrayList<>();
 
@@ -64,7 +61,7 @@ public class MemberEntity implements UserDetails {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Override
     public String getUsername() {
-        return this.nickname;
+        return this.username;
     }
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
@@ -92,7 +89,7 @@ public class MemberEntity implements UserDetails {
     }
 
     public void updateNickname(String nickname) {
-        this.nickname = nickname != null ? nickname : this.nickname;
+        this.username = nickname != null ? nickname : this.username;
     }
 
     public void updatePassword(String password) {
@@ -104,11 +101,11 @@ public class MemberEntity implements UserDetails {
         if (this == o) return true;
         if (!(o instanceof MemberEntity)) return false;
         MemberEntity that = (MemberEntity) o;
-        return Objects.equals(getUserIdx(), that.getUserIdx()) && Objects.equals(getNickname(), that.getNickname()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getPhoneNumber(), that.getPhoneNumber()) && getPermission() == that.getPermission() && Objects.equals(getRoles(), that.getRoles());
+        return Objects.equals(getUserIdx(), that.getUserIdx()) && Objects.equals(getUsername(), that.getUsername()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getPhoneNumber(), that.getPhoneNumber()) && getPermission() == that.getPermission() && Objects.equals(getRoles(), that.getRoles());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUserIdx(), getNickname(), getPassword(), getPhoneNumber(), getPermission(), getRoles());
+        return Objects.hash(getUserIdx(), getUsername(), getPassword(), getPhoneNumber(), getPermission(), getRoles());
     }
 }

--- a/src/main/java/com/server/EZY/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.server.EZY.model.member.controller;
 
 import com.server.EZY.model.member.dto.AuthDto;
-import com.server.EZY.model.member.dto.NicknameChangeDto;
+import com.server.EZY.model.member.dto.UsernameChangeDto;
 import com.server.EZY.model.member.dto.PasswordChangeDto;
 import com.server.EZY.model.member.dto.MemberDto;
 import com.server.EZY.model.member.service.MemberService;
@@ -54,13 +54,13 @@ public class MemberController {
 
     /**
      * nickname 변경 controller
-     * @param nicknameChangeDto nickname, newNickname
+     * @param usernameChangeDto username, newUsername
      * @return
      */
-    @PutMapping("/change/nickname")
+    @PutMapping("/change/username")
     @ResponseStatus( HttpStatus.OK )
-    public CommonResult changeUsername(@Valid @RequestBody NicknameChangeDto nicknameChangeDto) {
-        memberService.changeNickname(nicknameChangeDto);
+    public CommonResult changeUsername(@Valid @RequestBody UsernameChangeDto usernameChangeDto) {
+        memberService.changeUsername(usernameChangeDto);
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/EZY/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
     /**
      * 로그인 controller
      * @param loginDto loginDto
-     * @return nickname ,accessToken, refreshToken
+     * @return username ,accessToken, refreshToken
      * @throws Exception Exception
      * @author 배태현
      */
@@ -53,7 +53,7 @@ public class MemberController {
     }
 
     /**
-     * nickname 변경 controller
+     * username 변경 controller
      * @param usernameChangeDto username, newUsername
      * @return
      */

--- a/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 @Builder
 public class AuthDto {
 
-    @NotBlank(message = "nickname should be valid")
+    @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
     private String username;
 

--- a/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
@@ -1,7 +1,5 @@
 package com.server.EZY.model.member.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.server.EZY.model.member.enumType.Permission;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.MemberEntity;
 import lombok.*;
@@ -11,32 +9,27 @@ import javax.validation.constraints.Size;
 import java.util.Collections;
 
 @Getter @Setter
-@AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class AuthDto {
 
     @NotBlank(message = "nickname should be valid")
     @Size(min = 1, max = 10)
-    private String nickname;
+    private String username;
 
     @NotBlank(message = "password should be valid")
     @Size(min = 4, max = 10)
     private String password;
 
-    @JsonIgnore
-    private Permission permission;
-
-    public AuthDto(String nickname, String password) {
-        this.nickname = nickname;
+    public AuthDto(String username, String password) {
+        this.username = username;
         this.password = password;
     }
 
     public MemberEntity toEntity(){
         return MemberEntity.builder()
-                .nickname(this.getNickname())
+                .username(this.getUsername())
                 .password(this.getPassword())
-                .permission(Permission.PERMISSION)
                 .roles(Collections.singletonList(Role.ROLE_CLIENT))
                 .build();
     }

--- a/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 @Getter @Setter @Builder
 @NoArgsConstructor
 public class MemberDto {
-    @NotBlank(message = "nickname should be valid")
+    @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
     private String username;
 

--- a/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
@@ -1,8 +1,6 @@
 package com.server.EZY.model.member.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.server.EZY.model.member.MemberEntity;
-import com.server.EZY.model.member.enumType.Permission;
 import com.server.EZY.model.member.enumType.Role;
 import lombok.*;
 
@@ -11,11 +9,11 @@ import javax.validation.constraints.Size;
 import java.util.Collections;
 
 @Getter @Setter @Builder
-@AllArgsConstructor @NoArgsConstructor
+@NoArgsConstructor
 public class MemberDto {
     @NotBlank(message = "nickname should be valid")
     @Size(min = 1, max = 10)
-    private String nickname;
+    private String username;
 
     @NotBlank(message = "password should be valid")
     @Size(min = 4, max = 10)
@@ -25,21 +23,17 @@ public class MemberDto {
     @Size(min = 11, max = 11)
     private String phoneNumber;
 
-    @JsonIgnore
-    private Permission permission;
-
-    public MemberDto(String nickname, String password, String phoneNumber) {
-        this.nickname = nickname;
+    public MemberDto(String username, String password, String phoneNumber) {
+        this.username = username;
         this.password = password;
         this.phoneNumber = phoneNumber;
     }
 
     public MemberEntity toEntity(){
         return MemberEntity.builder()
-                .nickname(this.getNickname())
+                .username(this.getUsername())
                 .password(this.getPassword())
                 .phoneNumber(this.getPhoneNumber())
-                .permission(Permission.PERMISSION)
                 .roles(Collections.singletonList(Role.ROLE_CLIENT))
                 .build();
     }

--- a/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor @AllArgsConstructor
 public class PasswordChangeDto {
 
-    @NotBlank(message = "nickname should be valid")
+    @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
     private String username;
 

--- a/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
@@ -11,7 +11,7 @@ public class PasswordChangeDto {
 
     @NotBlank(message = "nickname should be valid")
     @Size(min = 1, max = 10)
-    private String nickname;
+    private String username;
 
     @NotBlank(message = "newPassword should be valid")
     @Size(min = 4, max = 10)

--- a/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
@@ -9,11 +9,11 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor @NoArgsConstructor
 public class UsernameChangeDto {
 
-    @NotBlank(message = "nickname should be valid")
+    @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
     private String username;
 
-    @NotBlank(message = "NewNickname should be valid")
+    @NotBlank(message = "NewUsername should be valid")
     @Size(min = 1, max = 10)
     private String newUsername;
 }

--- a/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
@@ -11,9 +11,9 @@ public class NicknameChangeDto {
 
     @NotBlank(message = "nickname should be valid")
     @Size(min = 1, max = 10)
-    private String nickname;
+    private String username;
 
     @NotBlank(message = "NewNickname should be valid")
     @Size(min = 1, max = 10)
-    private String NewNickname;
+    private String NewUsername;
 }

--- a/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/UsernameChangeDto.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.Size;
 
 @Getter @Setter @Builder
 @AllArgsConstructor @NoArgsConstructor
-public class NicknameChangeDto {
+public class UsernameChangeDto {
 
     @NotBlank(message = "nickname should be valid")
     @Size(min = 1, max = 10)
@@ -15,5 +15,5 @@ public class NicknameChangeDto {
 
     @NotBlank(message = "NewNickname should be valid")
     @Size(min = 1, max = 10)
-    private String NewUsername;
+    private String newUsername;
 }

--- a/src/main/java/com/server/EZY/model/member/enumType/Permission.java
+++ b/src/main/java/com/server/EZY/model/member/enumType/Permission.java
@@ -1,5 +1,0 @@
-package com.server.EZY.model.member.enumType;
-
-public enum Permission {
-    NONE, PERMISSION
-}

--- a/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     // MyUserDetails 에서 사용.
-    MemberEntity findByNickname(String nickName);
+    MemberEntity findByUsername(String username);
     // UserService 에서 사용.
-    boolean existsByNickname(String nickname);
+    boolean existsByUsername(String username);
     MemberEntity findByPhoneNumber(String phoneNumber);
 }
+

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -33,7 +33,7 @@ public interface MemberService {
 
     String validAuthKey(String key);
 
-    String changeNickname(NicknameChangeDto nicknameChangeDto);
+    String changeUsername(UsernameChangeDto usernameChangeDto);
 
     String changePassword(PasswordChangeDto passwordChangeDto);
 

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -20,7 +20,7 @@ public interface MemberService {
     /**
      * 로그인을 하는 서비스 로직 입니다.
      * @param loginDto
-     * @exception 1. nickname을 통해 회원을 찾을 수 있나요? -> false, UserNotFoundException();
+     * @exception 1. username을 통해 회원을 찾을 수 있나요? -> false, UserNotFoundException();
      * @exception 2. 해당 회원의 비밀번호가 loginDto.getPassword()와 일치하나요? -> false, UserNotFoundException();
      * @return 서두에 있는 모든 조건을 만족할 시에  Map<String ,String> 을 반환 합니다.
      * @author 전지환

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -106,7 +106,7 @@ public class MemberServiceImpl implements MemberService {
         if (findByPhoneNumber == null) throw new UserNotFoundException(); //인증번호 발송 실패
 
         String authKey = keyUtil.getKey(4);
-        redisUtil.setDataExpire(authKey, findByPhoneNumber.getNickname(), KEY_EXPIRATION_TIME);
+        redisUtil.setDataExpire(authKey, findByPhoneNumber.getUsername(), KEY_EXPIRATION_TIME);
 
         Message coolsms = new Message(apiKey, apiSecret);
         HashMap<String, String> params = new HashMap<String, String>();

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -45,11 +45,11 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public String signup(MemberDto memberDto) {
-        if(!memberRepository.existsByNickname(memberDto.getNickname())){
+        if(!memberRepository.existsByUsername(memberDto.getUsername())){
             memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
             memberRepository.save(memberDto.toEntity());
 
-            String token = jwtTokenProvider.createToken(memberDto.getNickname(), memberDto.toEntity().getRoles());
+            String token = jwtTokenProvider.createToken(memberDto.getUsername(), memberDto.toEntity().getRoles());
 
             return "Bearer " + token;
         } else {
@@ -59,20 +59,20 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Map<String, String> signin(AuthDto loginDto) {
-        MemberEntity findUser = memberRepository.findByNickname(loginDto.getNickname());
+        MemberEntity findUser = memberRepository.findByUsername(loginDto.getUsername());
         if (findUser == null) throw new UserNotFoundException();
         // 비밀번호 검증
         boolean passwordCheck = passwordEncoder.matches(loginDto.getPassword(), findUser.getPassword());
         if (!passwordCheck) throw new UserNotFoundException();
 
-        String accessToken = jwtTokenProvider.createToken(loginDto.getNickname(), loginDto.toEntity().getRoles());
+        String accessToken = jwtTokenProvider.createToken(loginDto.getUsername(), loginDto.toEntity().getRoles());
         String refreshToken = jwtTokenProvider.createRefreshToken();
 
-        redisUtil.deleteData(loginDto.getNickname()); // accessToken이 만료되지않아도 로그인 할 때 refreshToken도 초기화해서 다시 생성 후 redis에 저장한다.
+        redisUtil.deleteData(loginDto.getUsername()); // accessToken이 만료되지않아도 로그인 할 때 refreshToken도 초기화해서 다시 생성 후 redis에 저장한다.
 
-        redisUtil.setDataExpire(loginDto.getNickname(), refreshToken, REDIS_EXPIRATION_TIME);
+        redisUtil.setDataExpire(loginDto.getUsername(), refreshToken, REDIS_EXPIRATION_TIME);
         Map<String ,String> map = new HashMap<>();
-        map.put("nickname", loginDto.getNickname());
+        map.put("username", loginDto.getUsername());
         map.put("accessToken", "Bearer " + accessToken); // accessToken 반환
         map.put("refreshToken", "Bearer " + refreshToken); // refreshToken 반환
 
@@ -136,40 +136,40 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public String validAuthKey(String key) {
         String username = redisUtil.getData(key);
-        MemberEntity findUser = memberRepository.findByNickname(username);
+        MemberEntity findUser = memberRepository.findByUsername(username);
         if (findUser == null) throw new InvalidAuthenticationNumberException();
         redisUtil.deleteData(key);
         return username + "님 휴대전화 인증 완료";
     }
 
     /**
-     * nickname을 변경하는 서비스 로직
-     * @param nicknameChangeDto nickname, newNickname
+     * username을 변경하는 서비스 로직
+     * @param usernameChangeDto username, newUsername
      * @return
      */
     @Override
     @Transactional
-    public String changeNickname(NicknameChangeDto nicknameChangeDto) {
-        MemberEntity findUser = memberRepository.findByNickname(nicknameChangeDto.getNickname());
+    public String changeUsername(UsernameChangeDto usernameChangeDto) {
+        MemberEntity findUser = memberRepository.findByUsername(usernameChangeDto.getUsername());
         if (findUser == null) throw new UserNotFoundException();
-        findUser.updateNickname(nicknameChangeDto.getNewNickname());
-        return nicknameChangeDto.getNickname() + "유저 " + nicknameChangeDto.getNewNickname() + "(으)로 닉네임 업데이트 완료";
+        findUser.updateUsername(usernameChangeDto.getNewUsername());
+        return usernameChangeDto.getUsername() + "유저 " + usernameChangeDto.getNewUsername() + "(으)로 닉네임 업데이트 완료";
     }
 
     /**
      * 비밀번호를 변경하는 서비스 로직
-     * @param passwordChangeDto nickname, newPassword
+     * @param passwordChangeDto username, newPassword
      * @return (회원닉네임)회원 비밀번호 변경완료
      * @author 배태현
      */
     @Override
     @Transactional
     public String changePassword(PasswordChangeDto passwordChangeDto) {
-        MemberEntity findUser = memberRepository.findByNickname(passwordChangeDto.getNickname());
+        MemberEntity findUser = memberRepository.findByUsername(passwordChangeDto.getUsername());
         if (findUser == null) throw new UserNotFoundException();
         findUser.updatePassword(passwordEncoder.encode(passwordChangeDto.getNewPassword()));
 
-        return passwordChangeDto.getNickname() + "회원 비밀번호 변경완료";
+        return passwordChangeDto.getUsername() + "회원 비밀번호 변경완료";
     }
 
     /**
@@ -180,11 +180,11 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public String deleteUser(AuthDto deleteUserDto) {
-        MemberEntity findUser = memberRepository.findByNickname(deleteUserDto.getNickname());
+        MemberEntity findUser = memberRepository.findByUsername(deleteUserDto.getUsername());
         if (findUser == null) throw new UserNotFoundException();
         if (passwordEncoder.matches(deleteUserDto.getPassword(), findUser.getPassword())) {
             memberRepository.deleteById(findUser.getUserIdx());
         }
-        return deleteUserDto.getNickname() + "회원 회원탈퇴완료";
+        return deleteUserDto.getUsername() + "회원 회원탈퇴완료";
     }
 }

--- a/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenService.java
+++ b/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenService.java
@@ -9,7 +9,7 @@ public interface RefreshTokenService {
     /**
      * accessToken과 refresh토큰을 이용하여 새로운 accessToken과 refreshToken을 생성하는 메서드
      * @param request HttpServletRequest
-     * @return nickname, newAccessToken, newRefreshToken
+     * @return username, newAccessToken, newRefreshToken
      * @author 배태현
      */
     Map<String, String> getRefreshToken(HttpServletRequest request);

--- a/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
@@ -33,19 +33,19 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         String newAccessToken = null;
         String newRefreshToken = null;
 
-        String nickname = jwtTokenProvider.getUsername(accessToken);
+        String username = jwtTokenProvider.getUsername(accessToken);
 
-        MemberEntity findUser = memberRepository.findByNickname(nickname);
+        MemberEntity findUser = memberRepository.findByUsername(username);
         List<Role> roles = findUser.getRoles();
 
-        if (redisUtil.getData(nickname) == null) throw new TokenLoggedOutException();
+        if (redisUtil.getData(username) == null) throw new TokenLoggedOutException();
 
-        if (redisUtil.getData(nickname).equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)) {
-            redisUtil.deleteData(nickname);//refreshToken이 저장되어있는 레디스 초기화 후
-            newAccessToken = jwtTokenProvider.createToken(nickname, roles);
+        if (redisUtil.getData(username).equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)) {
+            redisUtil.deleteData(username);//refreshToken이 저장되어있는 레디스 초기화 후
+            newAccessToken = jwtTokenProvider.createToken(username, roles);
             newRefreshToken = jwtTokenProvider.createRefreshToken();
-            redisUtil.setDataExpire(nickname, newRefreshToken, 360000 * 1000l* 24 * 180); //새 refreshToken을 다시 저장
-            map.put("nickname", nickname);
+            redisUtil.setDataExpire(username, newRefreshToken, 360000 * 1000l* 24 * 180); //새 refreshToken을 다시 저장
+            map.put("username", username);
             map.put("NewAccessToken", "Bearer " + newAccessToken); // NewAccessToken 반환
             map.put("NewRefreshToken", "Bearer " + newRefreshToken); // NewRefreshToken 반환
             return map;

--- a/src/main/java/com/server/EZY/model/plan/personal/NewPersonalPlanEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/NewPersonalPlanEntity.java
@@ -21,7 +21,7 @@ public class NewPersonalPlanEntity {
     private Long personalPlanIdx;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "member_id")
     private MemberEntity memberEntity;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/server/EZY/model/plan/tag/TagEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/tag/TagEntity.java
@@ -12,7 +12,7 @@ public class TagEntity {
     private Long tagIdx;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "member_id")
     private MemberEntity memberEntity;
 
     private String tag;

--- a/src/main/java/com/server/EZY/security/Authentication/MyUserDetails.java
+++ b/src/main/java/com/server/EZY/security/Authentication/MyUserDetails.java
@@ -15,11 +15,11 @@ public class MyUserDetails implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        MemberEntity memberEntity = memberRepository.findByUsername(nickname);
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        MemberEntity memberEntity = memberRepository.findByUsername(username);
 
-        if(nickname == null){
-            throw new UsernameNotFoundException("nickName '" + nickname + "' not found");
+        if(username == null){
+            throw new UsernameNotFoundException("username '" + username + "' not found");
         }
 
         return memberEntity;

--- a/src/main/java/com/server/EZY/security/Authentication/MyUserDetails.java
+++ b/src/main/java/com/server/EZY/security/Authentication/MyUserDetails.java
@@ -16,7 +16,7 @@ public class MyUserDetails implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        MemberEntity memberEntity = memberRepository.findByNickname(nickname);
+        MemberEntity memberEntity = memberRepository.findByUsername(nickname);
 
         if(nickname == null){
             throw new UsernameNotFoundException("nickName '" + nickname + "' not found");

--- a/src/main/java/com/server/EZY/security/SecurityConfig.java
+++ b/src/main/java/com/server/EZY/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v1/member/signin").permitAll()//
                 .antMatchers("/v1/member/signup").permitAll()//
                 .antMatchers("/v1/member/refreshtoken").permitAll()//
-                .antMatchers("/v1/member/change/nickname").permitAll()//
+                .antMatchers("/v1/member/change/username").permitAll()//
                 .antMatchers("/v1/member/change/password").permitAll()//
                 .antMatchers("/v1/member/auth").permitAll()//
                 .antMatchers("/v1/member/auth/check").permitAll()//

--- a/src/main/java/com/server/EZY/util/CurrentUserUtil.java
+++ b/src/main/java/com/server/EZY/util/CurrentUserUtil.java
@@ -18,7 +18,7 @@ public class CurrentUserUtil {
      * @return nickname
      * @author 배태현
      */
-    public static String getCurrentUserNickname() {
+    public static String getCurrentUsername() {
         String nickname = null;
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if(principal instanceof UserDetails) {
@@ -30,13 +30,13 @@ public class CurrentUserUtil {
     }
 
     public MemberEntity getCurrentUser() {
-        String nickname = null;
+        String username = null;
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if(principal instanceof UserDetails) {
-            nickname = ((UserDetails) principal).getUsername();
+            username = ((UserDetails) principal).getUsername();
         } else{
-            nickname = principal.toString();
+            username = principal.toString();
         }
-        return memberRepository.findByNickname(nickname);
+        return memberRepository.findByUsername(username);
     }
 }

--- a/src/main/java/com/server/EZY/util/CurrentUserUtil.java
+++ b/src/main/java/com/server/EZY/util/CurrentUserUtil.java
@@ -14,19 +14,19 @@ public class CurrentUserUtil {
     private final MemberRepository memberRepository;
 
     /**
-     * 현재 로그인 되어있는(인증되어있는) User의 nickname을 반환하는 메서드
-     * @return nickname
+     * 현재 로그인 되어있는(인증되어있는) User의 username을 반환하는 메서드
+     * @return username
      * @author 배태현
      */
     public static String getCurrentUsername() {
-        String nickname = null;
+        String username = null;
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if(principal instanceof UserDetails) {
-            nickname = ((UserDetails) principal).getUsername();
+            username = ((UserDetails) principal).getUsername();
         } else{
-            nickname = principal.toString();
+            username = principal.toString();
         }
-        return nickname;
+        return username;
     }
 
     public MemberEntity getCurrentUser() {

--- a/src/test/java/com/server/EZY/model/member/MemberEntityTest.java
+++ b/src/test/java/com/server/EZY/model/member/MemberEntityTest.java
@@ -1,6 +1,5 @@
 package com.server.EZY.model.member;
 
-import com.server.EZY.model.member.enumType.Permission;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;
@@ -30,10 +29,9 @@ class MemberEntityTest {
 
         // Given
         MemberEntity memberEntity = MemberEntity.builder()
-                .nickname("JsonWebTok")
+                .username("JsonWebTok")
                 .password("JsonWebTok")
                 .phoneNumber("01012345678")
-                .permission(Permission.PERMISSION)
                 .roles(Collections.singletonList(Role.ROLE_ADMIN))
                 .build();
 
@@ -54,8 +52,7 @@ class MemberEntityTest {
         userRole.add(Role.ROLE_CLIENT);
         userRole.add(Role.ROLE_ADMIN);
         MemberEntity memberEntity = MemberEntity.builder()
-                .nickname("siwony")
-                .permission(Permission.PERMISSION)
+                .username("siwony")
                 .password("siwony1234")
                 .phoneNumber("01037283839")
                 .roles(userRole)

--- a/src/test/java/com/server/EZY/model/member/MemberEntityTest.java
+++ b/src/test/java/com/server/EZY/model/member/MemberEntityTest.java
@@ -4,7 +4,6 @@ import com.server.EZY.model.member.enumType.Permission;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-
-import javax.validation.ConstraintViolationException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -76,7 +73,7 @@ class MemberEntityTest {
         boolean getEnabled = memberEntity.isEnabled();
 
         // Then
-        assertEquals(getUsername, memberEntity.getNickname());
+        assertEquals(getUsername, memberEntity.getUsername());
         assertEquals(getAuthorities, getRoleConvertSimpleGrantedAuthority);
         assertEquals(getAccountNonExpired, true);
         assertEquals(getAccountNonLocked, true);

--- a/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
@@ -51,7 +51,7 @@ public class CertifiedMemberControllerTest {
     public void withdrawalTest() throws Exception {
 
         AuthDto deleteUserDto = AuthDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .build();
 

--- a/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
@@ -40,7 +40,7 @@ public class MemberControllerTest {
         mvc = MockMvcBuilders.standaloneSetup(memberController).build();
 
         MemberDto memberDto = MemberDto.builder()
-                .nickname("JsonWebTok")
+                .username("JsonWebTok")
                 .password("1234")
                 .phoneNumber("01012345678")
                 .build();
@@ -51,7 +51,7 @@ public class MemberControllerTest {
     @DisplayName("회원가입 테스트")
     public void signupTest() throws Exception {
         MemberDto memberDto = MemberDto.builder()
-                .nickname("JsonWebTok")
+                .username("JsonWebTok")
                 .password("1234")
                 .phoneNumber("01012345678")
                 .build();
@@ -72,7 +72,7 @@ public class MemberControllerTest {
     @DisplayName("로그인 테스트")
     public void signInTest() throws Exception {
         AuthDto loginDto = AuthDto.builder()
-                .nickname("JsonWebTok")
+                .username("JsonWebTok")
                 .password("1234")
                 .build();
 
@@ -93,7 +93,7 @@ public class MemberControllerTest {
     public void pwdChangeTest() throws Exception {
 
         PasswordChangeDto passwordChangeDto = PasswordChangeDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .newPassword("string")
                 .build();
 

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -48,7 +48,7 @@ public class MemberServiceTest {
     void GetUserEntity(){
         //Given
         MemberDto memberDto = MemberDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .phoneNumber("01012341234")
                 .build();
@@ -59,7 +59,7 @@ public class MemberServiceTest {
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                memberDto.getNickname(),
+                memberDto.getUsername(),
                 memberDto.getPassword(),
                 List.of(new SimpleGrantedAuthority(Role.ROLE_CLIENT.name())));
         SecurityContext context = SecurityContextHolder.getContext();
@@ -68,7 +68,7 @@ public class MemberServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = CurrentUserUtil.getCurrentUserNickname();
+        String currentUserNickname = CurrentUserUtil.getCurrentUsername();
         assertEquals("배태현", currentUserNickname);
     }
 
@@ -77,7 +77,7 @@ public class MemberServiceTest {
     public void signupTest() {
         //given
         MemberDto memberDto = MemberDto.builder()
-                .nickname("나야나 배따횬~~")
+                .username("나야나 배따횬~~")
                 .password("0809")
                 .phoneNumber("01008090809")
                 .build();
@@ -92,7 +92,7 @@ public class MemberServiceTest {
     public void before(@Autowired MemberController memberController) {
 
         MemberDto memberDto = MemberDto.builder()
-                .nickname("바따햔")
+                .username("바따햔")
                 .password("0809")
                 .phoneNumber("01012345678")
                 .build();
@@ -104,7 +104,7 @@ public class MemberServiceTest {
     public void signinTest() {
         //given
         AuthDto loginDto = AuthDto.builder()
-                .nickname("바따햔")
+                .username("바따햔")
                 .password("0809")
                 .build();
         //when
@@ -114,18 +114,18 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("닉네임 변경 테스트")
-    public void changeNickname() {
+    @DisplayName("Username 변경 테스트")
+    public void changeUsername() {
         //given
         MemberEntity currentUser = currentUser();
 
-        NicknameChangeDto nicknameChangeDto = NicknameChangeDto.builder()
-                .nickname("바따햔")
-                .NewNickname("배태현")
+        UsernameChangeDto usernameChangeDto = UsernameChangeDto.builder()
+                .username("바따햔")
+                .newUsername("배태현")
                 .build();
         //when //then
         if (currentUser != null) {
-            String changeNickname = memberService.changeNickname(nicknameChangeDto);
+            String changeNickname = memberService.changeUsername(usernameChangeDto);
             assertEquals("바따햔유저 배태현(으)로 닉네임 업데이트 완료", changeNickname);
         } else {
             log.info("닉네임 변경테스트 실패");
@@ -139,7 +139,7 @@ public class MemberServiceTest {
         MemberEntity currentUser = currentUser();
 
         PasswordChangeDto passwordChangeDto = PasswordChangeDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .newPassword("20040809")
                 .build();
         //when //then
@@ -158,7 +158,7 @@ public class MemberServiceTest {
         MemberEntity currentUser = currentUser();
 
         AuthDto deleteUserDto = AuthDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .build();
 
@@ -178,7 +178,7 @@ public class MemberServiceTest {
      */
     public MemberEntity currentUser() {
         MemberDto memberDto = MemberDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .phoneNumber("01012341234")
                 .build();
@@ -189,7 +189,7 @@ public class MemberServiceTest {
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                memberDto.getNickname(),
+                memberDto.getUsername(),
                 memberDto.getPassword(),
                 List.of(new SimpleGrantedAuthority(Role.ROLE_CLIENT.name())));
         SecurityContext context = SecurityContextHolder.getContext();
@@ -198,9 +198,9 @@ public class MemberServiceTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = CurrentUserUtil.getCurrentUserNickname();
+        String currentUserNickname = CurrentUserUtil.getCurrentUsername();
         assertEquals("배태현", currentUserNickname);
-        MemberEntity loginUser = memberRepository.findByNickname(currentUserNickname);
+        MemberEntity loginUser = memberRepository.findByUsername(currentUserNickname);
         return loginUser;
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
@@ -6,7 +6,6 @@ import com.server.EZY.model.plan.PlanInfo;
 import com.server.EZY.model.plan.personal.enumType.PlanDType;
 import com.server.EZY.model.plan.personal.dto.NewPersonalPlanUpdateDto;
 import com.server.EZY.model.plan.personal.repository.NewPersonalPlanRepository;
-import com.server.EZY.model.member.enumType.Permission;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;

--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
@@ -31,10 +31,9 @@ class PersonalPlanEntityTest {
 
     MemberEntity userEntityInit(){
         MemberEntity user = MemberEntity.builder()
-                .nickname(RandomString.make(10))
+                .username(RandomString.make(10))
                 .password(RandomString.make(10))
                 .phoneNumber("010"+ (int)(Math.random()* Math.pow(10, 8)))
-                .permission(Permission.PERMISSION)
                 .roles(Collections.singletonList(Role.ROLE_CLIENT))
                 .build();
         return userRepo.save(user);

--- a/src/test/java/com/server/EZY/security/SecurityTest.java
+++ b/src/test/java/com/server/EZY/security/SecurityTest.java
@@ -27,11 +27,11 @@ public class SecurityTest {
     public void tokenTest() {
 
         MemberDto memberDto = new MemberDto();
-        memberDto.setNickname("배태현");
+        memberDto.setUsername("배태현");
         memberDto.setPhoneNumber("010-1234-1234");
         memberDto.setPassword("1234");
 
-        String accessToken = jwtTokenProvider.createToken(memberDto.getNickname(), memberDto.toEntity().getRoles());
+        String accessToken = jwtTokenProvider.createToken(memberDto.getUsername(), memberDto.toEntity().getRoles());
         // 유효한 토큰인지 확인
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken)){
             String nickname = jwtTokenProvider.getUsername(accessToken);

--- a/src/test/java/com/server/EZY/util/CurrentUserUtilTest.java
+++ b/src/test/java/com/server/EZY/util/CurrentUserUtilTest.java
@@ -91,7 +91,7 @@ class CurrentUserUtilTest {
         //then
         MemberEntity currentUser = currentUserUtil.getCurrentUser();
         assertTrue(currentUser != null, "true");
-        assertEquals(memberDto.toEntity().getNickname(), currentUser.getNickname());
+        assertEquals(memberDto.toEntity().getUsername(), currentUser.getUsername());
         assertEquals(memberDto.toEntity().getPhoneNumber(), currentUser.getPhoneNumber());
     }
 }

--- a/src/test/java/com/server/EZY/util/CurrentUserUtilTest.java
+++ b/src/test/java/com/server/EZY/util/CurrentUserUtilTest.java
@@ -32,14 +32,14 @@ class CurrentUserUtilTest {
 
 
     /**
-     * currentUserUtil에 만든 getCurrentUserNickname 메서드가 잘 동작하는지 확인하는 메서드
+     * currentUserUtil에 만든 getCurrentUsername 메서드가 잘 동작하는지 확인하는 메서드
      * @author 배태현
      */
     @Test
-    public void currentUserNickname() {
+    public void currentUsername() {
         //given
         MemberDto memberDto = MemberDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .phoneNumber("01012341234")
                 .build();
@@ -49,7 +49,7 @@ class CurrentUserUtilTest {
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                memberDto.getNickname(),
+                memberDto.getUsername(),
                 memberDto.getPassword(),
                 List.of(new SimpleGrantedAuthority(Role.ROLE_CLIENT.name())));
         SecurityContext context = SecurityContextHolder.getContext();
@@ -58,8 +58,8 @@ class CurrentUserUtilTest {
         System.out.println(context);
 
         //then
-        String currentUserNickname = CurrentUserUtil.getCurrentUserNickname();
-        assertEquals("배태현", currentUserNickname);
+        String currentUsername = CurrentUserUtil.getCurrentUsername();
+        assertEquals("배태현", currentUsername);
     }
 
     /**
@@ -70,7 +70,7 @@ class CurrentUserUtilTest {
     public void currentUser() {
         //given
         MemberDto memberDto = MemberDto.builder()
-                .nickname("배태현")
+                .username("배태현")
                 .password("1234")
                 .phoneNumber("01012341234")
                 .build();
@@ -80,7 +80,7 @@ class CurrentUserUtilTest {
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                memberDto.getNickname(),
+                memberDto.getUsername(),
                 memberDto.getPassword(),
                 List.of(new SimpleGrantedAuthority(Role.ROLE_CLIENT.name())));
         SecurityContext context = SecurityContextHolder.getContext();


### PR DESCRIPTION
### 한 일
- `MemberEntity` 에`nickname` 변수명을 `username`으로 변경후 그에 맞춰 `MemberEntity`에 의존적인 모든 서비스의 `nickname` 을 `username`으로 모두 다 변경했습니다.  (DTO, TestCode, 주석 등..)
- 테스트 도중 `BaseTimeEntity`에서 수정시간이 생성시간과 똑같아지는 현상을 발견 후 해당 버그를 수정했습니다.

## 논리적 오류 발견
### `MyUserDetails` 에 `loadUserByUsername` 메서드속 `UsernameNotFoundException` 발생 조건
```java
    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
        MemberEntity memberEntity = memberRepository.findByUsername(username);

        if(username == null){
            throw new UsernameNotFoundException("username '" + username + "' not found");
        }

        return memberEntity;
    }
```
1. `UserNameNotFoundException`  발생 조건은 `username`이 `null`일때 발생합니다. (`if(username == null)`)
2. 만약 member테이블에 없는 siwony라는 `username`을 `loadUserByUsername` 메서드의 인수로 전달합니다.
3. 그러면 `loadUserByUsername`메서드는 `null`을 반환하게 됩니다. &rarr; 이유는 `username`이 `null`이 아니므로
4. 원래 의도는 `MemberEntity memberEntity = memberRepository.findByUsername(username);` 에서 `memberEntity`변수의 데이터가 `null`이라면 `UsernameNotFoundException`를 thorw 하는 로직으로 추측이 되요!  확인해주세요 @qoxogus

#### 관련테스트 코드
```java
@SpringBootTest
class MyUserDetailsTest {

    @Autowired MyUserDetails myUserDetails;

    @Test @DisplayName("loadUserByUsername 매서드에 등록 되지않은 유저의 username을 인수로 넘겨준다면?")
    void 없는_username를_인수로넘겨주면(){

        UserDetails userDetails = myUserDetails.loadUserByUsername("siwony");

        assertNull(userDetails, "UserDetails는 null이다.");
    }

    @Test @DisplayName("loadUserByUsername 매서드에 null을 인수로 넘겨준다면?")
    void username에서_null를_인수로넘겨주면(){

        assertThrows(
                UsernameNotFoundException.class,
                () -> myUserDetails.loadUserByUsername(null)
        );
    }

}
```
#### 테스트 결과
![image](https://user-images.githubusercontent.com/62932968/126836399-3f80648c-7226-457a-a0d9-583fff90d38f.png)

---

### `./gradlew clean test` 결과
![image](https://user-images.githubusercontent.com/62932968/126838590-4333ff69-f44c-47b1-92ac-eab57fa8ddf6.png)

![image](https://user-images.githubusercontent.com/62932968/126838637-f8f1f5ef-52cf-47bc-bea3-0b05f3437618.png)




