### PR TITLE
Feature/persoanl plan entity constructor

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/PlanEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/PlanEntity.java
@@ -14,8 +14,8 @@ import javax.persistence.*;
 @Entity @Table(name = "plan")
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "d_type") //d_type 자동 생성
-@Builder @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlanEntity extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,20 +45,9 @@ public class PlanEntity extends BaseTimeEntity {
      * @author 정시원
      */
     protected PlanEntity(MemberEntity memberEntity, TagEntity tagEntity, PlanInfo planInfo, Period period){
-        if(memberEntity != null && planInfo != null && period != null){
             this.memberEntity = memberEntity;
             this.tagEntity = tagEntity;
             this.planInfo = planInfo;
             this.period = period;
-        }else{
-            log.error("PlanEntity의 생성자에 null값이 인수로 주입되었습니다.\n" +
-                    "MemberEntity = {} \n" +
-                    "TagEntity = {}\n" +
-                    "PlanInfo = {}\n" +
-                    "Period = {}\n",
-                    memberEntity, tagEntity, planInfo, period
-            );
-            throw new NullPointerException("PlanEntity의 생성자에 null값이 인수로 주입되었습니다.");
-        }
     }
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/PersonalPlanEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/PersonalPlanEntity.java
@@ -1,5 +1,6 @@
 package com.server.EZY.model.plan.personal;
 
+import com.server.EZY.exception.user.exception.InvalidAccessException;
 import com.server.EZY.model.plan.PlanEntity;
 import com.server.EZY.model.plan.embeddedTypes.Period;
 import com.server.EZY.model.plan.embeddedTypes.PlanInfo;
@@ -28,6 +29,7 @@ public class PersonalPlanEntity extends PlanEntity {
      * @param repetition 반복여부
      * @author 정시원
      */
+    @Builder
     public PersonalPlanEntity(MemberEntity memberEntity, TagEntity tagEntity, PlanInfo planInfo, Period period, boolean repetition){
         super(memberEntity, tagEntity, planInfo, period);
         this.repetition = repetition;
@@ -37,22 +39,18 @@ public class PersonalPlanEntity extends PlanEntity {
      * personalPlan를 업데이트 하는 매서드
      * 현재 겍체에 저장되어있는 memberEntity와 업데이트를 하려는 currentMember를 동등성 비교를 해서 이 일정의 소유자일 경우에 이 객체를 변경할 수 있다.
      * @param currentMember 현제 로그인 한 유저
-     * @param tagEntity 변경할 테그
-     * @param planInfo 변경할 개인일정 정보
-     * @param period 변경할 개인일정 기간
-     * @param repetition 변경할 개인일정 반복
+     * @param personalPlanEntity 변경할 필드를 가지고 있는 PersonalPlanEntity 주로 DTO에서 toEntity 매서드로 생성된 PersonalPlanEntity를 인수로 넘겨받는다.
      * @author 정시원
      */
-    public void updatePersonalPlanEntity(MemberEntity currentMember, TagEntity tagEntity, PlanInfo planInfo, Period period, Boolean repetition) throws Exception {
+    public void updatePersonalPlanEntity(MemberEntity currentMember, PersonalPlanEntity personalPlanEntity) throws Exception {
         if (this.memberEntity.equals(currentMember)) {
-
-            this.tagEntity = tagEntity != null ? tagEntity : this.tagEntity;
-            this.planInfo = planInfo != null ? planInfo : this.planInfo;
-            this.period = period != null ? period : this.period;
-            this.repetition =  repetition != null ? repetition : this.repetition;
+            this.tagEntity = personalPlanEntity.tagEntity != null ? personalPlanEntity.tagEntity : this.tagEntity;
+            this.planInfo = personalPlanEntity.planInfo != null ? personalPlanEntity.planInfo : this.planInfo;
+            this.period = personalPlanEntity.period != null ? personalPlanEntity.period : this.period;
+            this.repetition =  personalPlanEntity.repetition != null ? personalPlanEntity.repetition : this.repetition;
         } else {
             log.debug("해당 개인일정을 다른 소유자가 변경할 수 없습니다..");
-            throw new Exception("해당 일정에 대한 접근권한이 없습니다."); // Exception 추가 예정
+            throw new InvalidAccessException();
         }
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/PersonalPlanEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/PersonalPlanEntity.java
@@ -37,8 +37,8 @@ public class PersonalPlanEntity extends PlanEntity {
 
     /**
      * personalPlan를 업데이트 하는 매서드
-     * 현재 겍체에 저장되어있는 memberEntity와 업데이트를 하려는 currentMember를 동등성 비교를 해서 이 일정의 소유자일 경우에 이 객체를 변경할 수 있다.
-     * @param currentMember 현제 로그인 한 유저
+     * 현재 변경하려는 personalPlan에 연관관계를 맻고있는 회원과 이 일정을 변경하려는 회원를 동등성 비교를 통해 현재 일정의 소유자여부를 판별한 후 객체를 업데이트 한다.
+     * @param currentMember 현재 로그인 한 유저
      * @param personalPlanEntity 변경할 필드를 가지고 있는 PersonalPlanEntity 주로 DTO에서 toEntity 매서드로 생성된 PersonalPlanEntity를 인수로 넘겨받는다.
      * @author 정시원
      */

--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
@@ -1,5 +1,6 @@
 package com.server.EZY.model.plan.personal;
 
+import com.server.EZY.exception.user.exception.InvalidAccessException;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
@@ -140,7 +141,15 @@ class PersonalPlanEntityTest {
         boolean repetition = false;
 
         // When
-        savedPersonalPlanEntity.updatePersonalPlanEntity(savedPersonalPlanEntity.getMemberEntity(), tagEntity, planInfo, period, repetition);
+        savedPersonalPlanEntity.updatePersonalPlanEntity(
+                savedPersonalPlanEntity.getMemberEntity(),
+                PersonalPlanEntity.builder()
+                        .tagEntity(tagEntity)
+                        .planInfo(planInfo)
+                        .period(period)
+                        .repetition(repetition)
+                        .build()
+                );
 
         // Then
         assertEquals(savedTagEntity, savedPersonalPlanEntity.getTagEntity(), savedPersonalPlanEntity.getTagEntity().getTag());
@@ -183,15 +192,17 @@ class PersonalPlanEntityTest {
 
         boolean repetition = false;
 
+
+
         // When Then
         assertThrows(
-                Exception.class,
+                InvalidAccessException.class,
                 () -> savedPersonalPlanEntity.updatePersonalPlanEntity(
                         savedOtherMember,
-                        tagEntity,
-                        planInfo,
-                        period,
-                        repetition
+                        PersonalPlanEntity.builder()
+                                .planInfo(planInfo)
+                                .period(period)
+                        .build()
                 )
         );
 


### PR DESCRIPTION
### 한 일
- @jyeonjyan 님의 의견대로 확장성과 가독성을 위해 생성자에 null 체킹을 하지 않고 builder 패턴을 통해 객체를 생성할 수 있도록 로직을 변경했습니다.
- `PersonalPlanEntity`에 `updatePersonalPlanEntity` 타입은 이제부터 `MemberEntity`타입과, `PersonalPlanEntity`타입을 매개변수로 받습니다.
   > 로직 설명은 주석 확인해주세요

### 테스트 결과
![image](https://user-images.githubusercontent.com/62932968/126904944-cde48aa3-247c-43d7-a2df-5c96b1181fe2.png)

![image](https://user-images.githubusercontent.com/62932968/126904972-fe7e8800-2710-4669-8332-20ea3413e2b2.png)

