### PR TITLE
exception로직 관련 가독성을 위한 class, 패키지 이름변경

### DIFF
--- a/src/main/java/com/server/EZY/exception/authenticationNumber/AuthenticationNumberExceptionHandler.java
+++ b/src/main/java/com/server/EZY/exception/authenticationNumber/AuthenticationNumberExceptionHandler.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-public interface AuthenticationNumberExceptionAdvice {
+public interface AuthenticationNumberExceptionHandler {
 
     String INVALID_AUTHENTICATION_NUMBER = "invalid-authentication-number";
     String AUTHENTICATION_NUMBER_TRANSFER_FAILED = "authentication-number-transfer-failed";

--- a/src/main/java/com/server/EZY/exception/authenticationNumber/AuthenticationNumberExceptionHandlerImpl.java
+++ b/src/main/java/com/server/EZY/exception/authenticationNumber/AuthenticationNumberExceptionHandlerImpl.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class AuthenticationNumberExceptionAdviceImpl implements AuthenticationNumberExceptionAdvice{
+public class AuthenticationNumberExceptionHandlerImpl implements AuthenticationNumberExceptionHandler {
 
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 

--- a/src/main/java/com/server/EZY/exception/customError/CustomErrorHandler.java
+++ b/src/main/java/com/server/EZY/exception/customError/CustomErrorHandler.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-public interface CustomErrorAdvice {
+public interface CustomErrorHandler {
 
     String CUSTOM_401_UNAUTHORIZED = "unauthorized";
     String CUSTOM_403_FORBIDDEN = "forbidden";

--- a/src/main/java/com/server/EZY/exception/customError/CustomErrorHandlerImpl.java
+++ b/src/main/java/com/server/EZY/exception/customError/CustomErrorHandlerImpl.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class CustomErrorAdviceImpl implements CustomErrorAdvice {
+public class CustomErrorHandlerImpl implements CustomErrorHandler {
 
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 

--- a/src/main/java/com/server/EZY/exception/token/TokenExceptionHandler.java
+++ b/src/main/java/com/server/EZY/exception/token/TokenExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-public interface TokenExceptionAdvice {
+public interface TokenExceptionHandler {
 
     String ACCESS_TOKEN_EXPIRED = "access-token-expired";
     String INVALID_TOKEN = "invalid-token";

--- a/src/main/java/com/server/EZY/exception/token/TokenExceptionHandlerImpl.java
+++ b/src/main/java/com/server/EZY/exception/token/TokenExceptionHandlerImpl.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class TokenExceptionAdviceImpl implements TokenExceptionAdvice{
+public class TokenExceptionHandlerImpl implements TokenExceptionHandler {
 
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 

--- a/src/main/java/com/server/EZY/exception/unknownException/UnknownExceptionHandler.java
+++ b/src/main/java/com/server/EZY/exception/unknownException/UnknownExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class UnknownExceptionAdvice {
+public class UnknownExceptionHandler {
 
     public static String DEFAULT_EXCEPTION = "unknown";
 

--- a/src/main/java/com/server/EZY/exception/user/MemberExceptionHandler.java
+++ b/src/main/java/com/server/EZY/exception/user/MemberExceptionHandler.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-public interface MemberExceptionAdvice {
+public interface MemberExceptionHandler {
 
     String MEMBER_NOT_FOUND = "member-not-found";
     String MEMBER_ALREADY_EXIST = "member-already-exist";

--- a/src/main/java/com/server/EZY/exception/user/MemberExceptionHandlerImpl.java
+++ b/src/main/java/com/server/EZY/exception/user/MemberExceptionHandlerImpl.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
-public class MemberExceptionAdviceImpl implements MemberExceptionAdvice{
+public class MemberExceptionHandlerImpl implements MemberExceptionHandler {
 
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 

--- a/src/test/java/com/server/EZY/exception/AuthenticationNumberExceptionHandlerTest.java
+++ b/src/test/java/com/server/EZY/exception/AuthenticationNumberExceptionHandlerTest.java
@@ -2,7 +2,7 @@ package com.server.EZY.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.EZY.exception.authenticationNumber.AuthenticationNumberExceptionAdvice;
+import com.server.EZY.exception.authenticationNumber.AuthenticationNumberExceptionHandler;
 import com.server.EZY.exception.authenticationNumber.exception.AuthenticationNumberTransferFailedException;
 import com.server.EZY.exception.authenticationNumber.exception.InvalidAuthenticationNumberException;
 import com.server.EZY.response.result.CommonResult;
@@ -23,11 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 @DisplayName("AuthenticationNumberExceptionAdvice test")
 @AutoConfigureMockMvc
-public class AuthenticationNumberExceptionAdviceTest {
+public class AuthenticationNumberExceptionHandlerTest {
 
     @Autowired ObjectMapper objMapper;
     @Autowired MessageSource messageSource;
-    @Autowired AuthenticationNumberExceptionAdvice authenticationNumberExceptionAdvice;
+    @Autowired
+    AuthenticationNumberExceptionHandler authenticationNumberExceptionHandler;
 
     // LocalContext의 locale을 변경한다.
     void setLocal(Locale locale){
@@ -54,15 +55,15 @@ public class AuthenticationNumberExceptionAdviceTest {
     void InvalidAuthenticationNumberException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int INVALID_AUTHENTICATION_NUMBER_CODE_KO = getExceptionCode(AuthenticationNumberExceptionAdvice.INVALID_AUTHENTICATION_NUMBER, Locale.KOREA);
-        final int INVALID_AUTHENTICATION_NUMBER_CODE_EN = getExceptionCode(AuthenticationNumberExceptionAdvice.INVALID_AUTHENTICATION_NUMBER, Locale.ENGLISH);
-        final String INVALID_AUTHENTICATION_NUMBER_MSG_KO = getExceptionMsg(AuthenticationNumberExceptionAdvice.INVALID_AUTHENTICATION_NUMBER, Locale.KOREA);
-        final String INVALID_AUTHENTICATION_NUMBER_MSG_EN = getExceptionMsg(AuthenticationNumberExceptionAdvice.INVALID_AUTHENTICATION_NUMBER, Locale.ENGLISH);
+        final int INVALID_AUTHENTICATION_NUMBER_CODE_KO = getExceptionCode(AuthenticationNumberExceptionHandler.INVALID_AUTHENTICATION_NUMBER, Locale.KOREA);
+        final int INVALID_AUTHENTICATION_NUMBER_CODE_EN = getExceptionCode(AuthenticationNumberExceptionHandler.INVALID_AUTHENTICATION_NUMBER, Locale.ENGLISH);
+        final String INVALID_AUTHENTICATION_NUMBER_MSG_KO = getExceptionMsg(AuthenticationNumberExceptionHandler.INVALID_AUTHENTICATION_NUMBER, Locale.KOREA);
+        final String INVALID_AUTHENTICATION_NUMBER_MSG_EN = getExceptionMsg(AuthenticationNumberExceptionHandler.INVALID_AUTHENTICATION_NUMBER, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = authenticationNumberExceptionAdvice.invalidAuthenticationNumberException(new InvalidAuthenticationNumberException());
+        CommonResult commonResult_KO = authenticationNumberExceptionHandler.invalidAuthenticationNumberException(new InvalidAuthenticationNumberException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = authenticationNumberExceptionAdvice.invalidAuthenticationNumberException(new InvalidAuthenticationNumberException());
+        CommonResult commonResult_EN = authenticationNumberExceptionHandler.invalidAuthenticationNumberException(new InvalidAuthenticationNumberException());
 
         // Then
         assertEquals(INVALID_AUTHENTICATION_NUMBER_CODE_KO, INVALID_AUTHENTICATION_NUMBER_CODE_EN);
@@ -81,15 +82,15 @@ public class AuthenticationNumberExceptionAdviceTest {
     void AuthenticationNumberTransferFailedException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_KO = getExceptionCode(AuthenticationNumberExceptionAdvice.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.KOREA);
-        final int AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_EN = getExceptionCode(AuthenticationNumberExceptionAdvice.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.ENGLISH);
-        final String AUTHENTICATION_NUMBER_TRANSFER_FAILED_MSG_KO = getExceptionMsg(AuthenticationNumberExceptionAdvice.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.KOREA);
-        final String AUTHENTICATION_NUMBER_TRANSFER_FAILED_MSG_EN = getExceptionMsg(AuthenticationNumberExceptionAdvice.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.ENGLISH);
+        final int AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_KO = getExceptionCode(AuthenticationNumberExceptionHandler.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.KOREA);
+        final int AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_EN = getExceptionCode(AuthenticationNumberExceptionHandler.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.ENGLISH);
+        final String AUTHENTICATION_NUMBER_TRANSFER_FAILED_MSG_KO = getExceptionMsg(AuthenticationNumberExceptionHandler.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.KOREA);
+        final String AUTHENTICATION_NUMBER_TRANSFER_FAILED_MSG_EN = getExceptionMsg(AuthenticationNumberExceptionHandler.AUTHENTICATION_NUMBER_TRANSFER_FAILED, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = authenticationNumberExceptionAdvice.authenticationNumberTransferFailedException(new AuthenticationNumberTransferFailedException());
+        CommonResult commonResult_KO = authenticationNumberExceptionHandler.authenticationNumberTransferFailedException(new AuthenticationNumberTransferFailedException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = authenticationNumberExceptionAdvice.authenticationNumberTransferFailedException(new AuthenticationNumberTransferFailedException());
+        CommonResult commonResult_EN = authenticationNumberExceptionHandler.authenticationNumberTransferFailedException(new AuthenticationNumberTransferFailedException());
 
         // Then
         assertEquals(AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_KO, AUTHENTICATION_NUMBER_TRANSFER_FAILED_CODE_EN);

--- a/src/test/java/com/server/EZY/exception/CustomErrorHandlerTest.java
+++ b/src/test/java/com/server/EZY/exception/CustomErrorHandlerTest.java
@@ -2,7 +2,7 @@ package com.server.EZY.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.EZY.exception.customError.CustomErrorAdvice;
+import com.server.EZY.exception.customError.CustomErrorHandler;
 import com.server.EZY.exception.customError.exception.CustomForbiddenException;
 import com.server.EZY.exception.customError.exception.CustomNotFoundException;
 import com.server.EZY.exception.customError.exception.CustomUnauthorizedException;
@@ -24,11 +24,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @Slf4j
 @SpringBootTest @DisplayName("ExceptionAdvice test")
 @AutoConfigureMockMvc
-class CustomErrorAdviceTest {
+class CustomErrorHandlerTest {
 
     @Autowired ObjectMapper objMapper;
     @Autowired MessageSource messageSource;
-    @Autowired CustomErrorAdvice exceptionAdvice;
+    @Autowired
+    CustomErrorHandler exceptionAdvice;
 
     // LocalContext의 locale을 변경한다.
     void setLocal(Locale locale){
@@ -54,10 +55,10 @@ class CustomErrorAdviceTest {
     void CustomUnauthorizedException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int CUSTOM_UNAUTHORIZED_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorAdvice.CUSTOM_401_UNAUTHORIZED, Locale.KOREA);
-        final int CUSTOM_UNAUTHORIZED_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorAdvice.CUSTOM_401_UNAUTHORIZED, Locale.ENGLISH);
-        final String CUSTOM_UNAUTHORIZED_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorAdvice.CUSTOM_401_UNAUTHORIZED, Locale.KOREA);
-        final String CUSTOM_UNAUTHORIZED_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorAdvice.CUSTOM_401_UNAUTHORIZED, Locale.ENGLISH);
+        final int CUSTOM_UNAUTHORIZED_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorHandler.CUSTOM_401_UNAUTHORIZED, Locale.KOREA);
+        final int CUSTOM_UNAUTHORIZED_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorHandler.CUSTOM_401_UNAUTHORIZED, Locale.ENGLISH);
+        final String CUSTOM_UNAUTHORIZED_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorHandler.CUSTOM_401_UNAUTHORIZED, Locale.KOREA);
+        final String CUSTOM_UNAUTHORIZED_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorHandler.CUSTOM_401_UNAUTHORIZED, Locale.ENGLISH);
 
         // When
         CommonResult commonResult_KO = exceptionAdvice.unauthorized(new CustomUnauthorizedException());
@@ -80,10 +81,10 @@ class CustomErrorAdviceTest {
     void CustomForbiddenException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int CUSTOM_FORBIDDEN_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorAdvice.CUSTOM_403_FORBIDDEN, Locale.KOREA);
-        final int CUSTOM_FORBIDDEN_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorAdvice.CUSTOM_403_FORBIDDEN, Locale.ENGLISH);
-        final String CUSTOM_FORBIDDEN_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorAdvice.CUSTOM_403_FORBIDDEN, Locale.KOREA);
-        final String CUSTOM_FORBIDDEN_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorAdvice.CUSTOM_403_FORBIDDEN, Locale.ENGLISH);
+        final int CUSTOM_FORBIDDEN_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorHandler.CUSTOM_403_FORBIDDEN, Locale.KOREA);
+        final int CUSTOM_FORBIDDEN_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorHandler.CUSTOM_403_FORBIDDEN, Locale.ENGLISH);
+        final String CUSTOM_FORBIDDEN_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorHandler.CUSTOM_403_FORBIDDEN, Locale.KOREA);
+        final String CUSTOM_FORBIDDEN_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorHandler.CUSTOM_403_FORBIDDEN, Locale.ENGLISH);
 
         // When
         CommonResult commonResult_KO = exceptionAdvice.forbiddenException(new CustomForbiddenException());
@@ -106,10 +107,10 @@ class CustomErrorAdviceTest {
     void CustomNotFoundException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int CUSTOM_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorAdvice.CUSTOM_404_NOT_FOUND, Locale.KOREA);
-        final int CUSTOM_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorAdvice.CUSTOM_404_NOT_FOUND, Locale.ENGLISH);
-        final String CUSTOM_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorAdvice.CUSTOM_404_NOT_FOUND, Locale.KOREA);
-        final String CUSTOM_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorAdvice.CUSTOM_404_NOT_FOUND, Locale.ENGLISH);
+        final int CUSTOM_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(CustomErrorHandler.CUSTOM_404_NOT_FOUND, Locale.KOREA);
+        final int CUSTOM_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(CustomErrorHandler.CUSTOM_404_NOT_FOUND, Locale.ENGLISH);
+        final String CUSTOM_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(CustomErrorHandler.CUSTOM_404_NOT_FOUND, Locale.KOREA);
+        final String CUSTOM_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(CustomErrorHandler.CUSTOM_404_NOT_FOUND, Locale.ENGLISH);
 
         // When
         CommonResult commonResult_KO = exceptionAdvice.notFoundException(new CustomNotFoundException());

--- a/src/test/java/com/server/EZY/exception/MemberExceptionHandlerTest.java
+++ b/src/test/java/com/server/EZY/exception/MemberExceptionHandlerTest.java
@@ -2,7 +2,7 @@ package com.server.EZY.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.EZY.exception.user.MemberExceptionAdvice;
+import com.server.EZY.exception.user.MemberExceptionHandler;
 import com.server.EZY.exception.user.exception.InvalidAccessException;
 import com.server.EZY.exception.user.exception.MemberAlreadyExistException;
 import com.server.EZY.exception.user.exception.MemberNotFoundException;
@@ -25,14 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 @DisplayName("ExceptionAdvice test")
 @AutoConfigureMockMvc
-public class MemberExceptionAdviceTest {
+public class MemberExceptionHandlerTest {
 
     @Autowired
     ObjectMapper objMapper;
     @Autowired
     MessageSource messageSource;
     @Autowired
-    MemberExceptionAdvice memberExceptionAdvice;
+    MemberExceptionHandler memberExceptionHandler;
 
     // LocalContext의 locale을 변경한다.
     void setLocal(Locale locale){
@@ -59,15 +59,15 @@ public class MemberExceptionAdviceTest {
     void MemberNotFoundException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionAdvice.MEMBER_NOT_FOUND, Locale.KOREA);
-        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionAdvice.MEMBER_NOT_FOUND, Locale.ENGLISH);
-        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionAdvice.MEMBER_NOT_FOUND, Locale.KOREA);
-        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionAdvice.MEMBER_NOT_FOUND, Locale.ENGLISH);
+        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionHandler.MEMBER_NOT_FOUND, Locale.KOREA);
+        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionHandler.MEMBER_NOT_FOUND, Locale.ENGLISH);
+        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionHandler.MEMBER_NOT_FOUND, Locale.KOREA);
+        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionHandler.MEMBER_NOT_FOUND, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = memberExceptionAdvice.memberNotFoundException(new MemberNotFoundException());
+        CommonResult commonResult_KO = memberExceptionHandler.memberNotFoundException(new MemberNotFoundException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = memberExceptionAdvice.memberNotFoundException(new MemberNotFoundException());
+        CommonResult commonResult_EN = memberExceptionHandler.memberNotFoundException(new MemberNotFoundException());
 
         // Then
         assertEquals(MEMBER_NOT_FOUND_EXCEPTION_CODE_KO, MEMBER_NOT_FOUND_EXCEPTION_CODE_EN);
@@ -85,15 +85,15 @@ public class MemberExceptionAdviceTest {
     void MemberAlreadyExistException() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionAdvice.MEMBER_ALREADY_EXIST, Locale.KOREA);
-        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionAdvice.MEMBER_ALREADY_EXIST, Locale.ENGLISH);
-        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionAdvice.MEMBER_ALREADY_EXIST, Locale.KOREA);
-        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionAdvice.MEMBER_ALREADY_EXIST, Locale.ENGLISH);
+        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionHandler.MEMBER_ALREADY_EXIST, Locale.KOREA);
+        final int MEMBER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionHandler.MEMBER_ALREADY_EXIST, Locale.ENGLISH);
+        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionHandler.MEMBER_ALREADY_EXIST, Locale.KOREA);
+        final String MEMBER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionHandler.MEMBER_ALREADY_EXIST, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = memberExceptionAdvice.memberAlreadyExistException(new MemberAlreadyExistException());
+        CommonResult commonResult_KO = memberExceptionHandler.memberAlreadyExistException(new MemberAlreadyExistException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = memberExceptionAdvice.memberAlreadyExistException(new MemberAlreadyExistException());
+        CommonResult commonResult_EN = memberExceptionHandler.memberAlreadyExistException(new MemberAlreadyExistException());
 
         // Then
         assertEquals(MEMBER_NOT_FOUND_EXCEPTION_CODE_KO, MEMBER_NOT_FOUND_EXCEPTION_CODE_EN);
@@ -111,16 +111,16 @@ public class MemberExceptionAdviceTest {
     void UsernameNotFoundException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int USERNAME_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionAdvice.USERNAME_NOT_FOUND, Locale.KOREA);
-        final int USERNAME_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionAdvice.USERNAME_NOT_FOUND, Locale.ENGLISH);
-        final String USERNAME_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionAdvice.USERNAME_NOT_FOUND, Locale.KOREA);
-        final String USERNAME_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionAdvice.USERNAME_NOT_FOUND, Locale.ENGLISH);
+        final int USERNAME_NOT_FOUND_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionHandler.USERNAME_NOT_FOUND, Locale.KOREA);
+        final int USERNAME_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionHandler.USERNAME_NOT_FOUND, Locale.ENGLISH);
+        final String USERNAME_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionHandler.USERNAME_NOT_FOUND, Locale.KOREA);
+        final String USERNAME_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionHandler.USERNAME_NOT_FOUND, Locale.ENGLISH);
 
         final String username = "siwony_";
         // When
-        CommonResult commonResult_KO = memberExceptionAdvice.usernameNotFoundException(new UsernameNotFoundException(username));
+        CommonResult commonResult_KO = memberExceptionHandler.usernameNotFoundException(new UsernameNotFoundException(username));
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = memberExceptionAdvice.usernameNotFoundException(new UsernameNotFoundException(username));
+        CommonResult commonResult_EN = memberExceptionHandler.usernameNotFoundException(new UsernameNotFoundException(username));
 
         // Then
         assertEquals(USERNAME_NOT_FOUND_EXCEPTION_CODE_KO, USERNAME_NOT_FOUND_EXCEPTION_CODE_EN);
@@ -138,15 +138,15 @@ public class MemberExceptionAdviceTest {
     void InvalidAccessException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int INVALID_ACCESS_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionAdvice.INVALID_ACCESS, Locale.KOREA);
-        final int INVALID_ACCESS_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionAdvice.INVALID_ACCESS, Locale.ENGLISH);
-        final String INVALID_ACCESS_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionAdvice.INVALID_ACCESS, Locale.KOREA);
-        final String INVALID_ACCESS_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionAdvice.INVALID_ACCESS, Locale.ENGLISH);
+        final int INVALID_ACCESS_EXCEPTION_CODE_KO = getExceptionCode(MemberExceptionHandler.INVALID_ACCESS, Locale.KOREA);
+        final int INVALID_ACCESS_EXCEPTION_CODE_EN = getExceptionCode(MemberExceptionHandler.INVALID_ACCESS, Locale.ENGLISH);
+        final String INVALID_ACCESS_EXCEPTION_MSG_KO = getExceptionMsg(MemberExceptionHandler.INVALID_ACCESS, Locale.KOREA);
+        final String INVALID_ACCESS_EXCEPTION_MSG_EN = getExceptionMsg(MemberExceptionHandler.INVALID_ACCESS, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = memberExceptionAdvice.invalidAccessException(new InvalidAccessException());
+        CommonResult commonResult_KO = memberExceptionHandler.invalidAccessException(new InvalidAccessException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = memberExceptionAdvice.invalidAccessException(new InvalidAccessException());
+        CommonResult commonResult_EN = memberExceptionHandler.invalidAccessException(new InvalidAccessException());
 
         // Then
         assertEquals(INVALID_ACCESS_EXCEPTION_CODE_KO, INVALID_ACCESS_EXCEPTION_CODE_EN);

--- a/src/test/java/com/server/EZY/exception/TokenExceptionHandlerTest.java
+++ b/src/test/java/com/server/EZY/exception/TokenExceptionHandlerTest.java
@@ -2,8 +2,7 @@ package com.server.EZY.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.EZY.exception.authenticationNumber.exception.AuthenticationNumberTransferFailedException;
-import com.server.EZY.exception.token.TokenExceptionAdvice;
+import com.server.EZY.exception.token.TokenExceptionHandler;
 import com.server.EZY.exception.token.exception.*;
 import com.server.EZY.response.result.CommonResult;
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 @DisplayName("TokenExceptionAdvice test")
 @AutoConfigureMockMvc
-public class TokenExceptionAdviceTest {
+public class TokenExceptionHandlerTest {
 
     @Autowired ObjectMapper objMapper;
     @Autowired MessageSource messageSource;
-    @Autowired TokenExceptionAdvice tokenExceptionAdvice;
+    @Autowired
+    TokenExceptionHandler tokenExceptionHandler;
 
     // LocalContext의 locale을 변경한다.
     void setLocal(Locale locale){
@@ -55,15 +55,15 @@ public class TokenExceptionAdviceTest {
     void AccessTokenException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int ACCESS_TOKEN_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionAdvice.ACCESS_TOKEN_EXPIRED, Locale.KOREA);
-        final int ACCESS_TOKEN_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionAdvice.ACCESS_TOKEN_EXPIRED, Locale.ENGLISH);
-        final String ACCESS_TOKEN_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionAdvice.ACCESS_TOKEN_EXPIRED, Locale.KOREA);
-        final String ACCESS_TOKEN_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionAdvice.ACCESS_TOKEN_EXPIRED, Locale.ENGLISH);
+        final int ACCESS_TOKEN_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionHandler.ACCESS_TOKEN_EXPIRED, Locale.KOREA);
+        final int ACCESS_TOKEN_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionHandler.ACCESS_TOKEN_EXPIRED, Locale.ENGLISH);
+        final String ACCESS_TOKEN_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionHandler.ACCESS_TOKEN_EXPIRED, Locale.KOREA);
+        final String ACCESS_TOKEN_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionHandler.ACCESS_TOKEN_EXPIRED, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = tokenExceptionAdvice.accessTokenExpiredException(new AccessTokenExpiredException());
+        CommonResult commonResult_KO = tokenExceptionHandler.accessTokenExpiredException(new AccessTokenExpiredException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = tokenExceptionAdvice.accessTokenExpiredException(new AccessTokenExpiredException());
+        CommonResult commonResult_EN = tokenExceptionHandler.accessTokenExpiredException(new AccessTokenExpiredException());
 
         // Then
         assertEquals(ACCESS_TOKEN_EXCEPTION_CODE_KO, ACCESS_TOKEN_EXCEPTION_CODE_EN);
@@ -81,15 +81,15 @@ public class TokenExceptionAdviceTest {
     void InvalidException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int INVALID_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionAdvice.INVALID_TOKEN, Locale.KOREA);
-        final int INVALID_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionAdvice.INVALID_TOKEN, Locale.ENGLISH);
-        final String INVALID_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionAdvice.INVALID_TOKEN, Locale.KOREA);
-        final String INVALID_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionAdvice.INVALID_TOKEN, Locale.ENGLISH);
+        final int INVALID_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionHandler.INVALID_TOKEN, Locale.KOREA);
+        final int INVALID_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionHandler.INVALID_TOKEN, Locale.ENGLISH);
+        final String INVALID_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionHandler.INVALID_TOKEN, Locale.KOREA);
+        final String INVALID_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionHandler.INVALID_TOKEN, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = tokenExceptionAdvice.invalidTokenException(new InvalidTokenException());
+        CommonResult commonResult_KO = tokenExceptionHandler.invalidTokenException(new InvalidTokenException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = tokenExceptionAdvice.invalidTokenException(new InvalidTokenException());
+        CommonResult commonResult_EN = tokenExceptionHandler.invalidTokenException(new InvalidTokenException());
 
         // Then
         assertEquals(INVALID_EXCEPTION_CODE_KO, INVALID_EXCEPTION_CODE_EN);
@@ -107,15 +107,15 @@ public class TokenExceptionAdviceTest {
     void TokenLoggedOutException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int TOKEN_LOGGED_OUT_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionAdvice.TOKEN_LOGGED_OUT, Locale.KOREA);
-        final int TOKEN_LOGGED_OUT_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionAdvice.TOKEN_LOGGED_OUT, Locale.ENGLISH);
-        final String TOKEN_LOGGED_OUT_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionAdvice.TOKEN_LOGGED_OUT, Locale.KOREA);
-        final String TOKEN_LOGGED_OUT_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionAdvice.TOKEN_LOGGED_OUT, Locale.ENGLISH);
+        final int TOKEN_LOGGED_OUT_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionHandler.TOKEN_LOGGED_OUT, Locale.KOREA);
+        final int TOKEN_LOGGED_OUT_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionHandler.TOKEN_LOGGED_OUT, Locale.ENGLISH);
+        final String TOKEN_LOGGED_OUT_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionHandler.TOKEN_LOGGED_OUT, Locale.KOREA);
+        final String TOKEN_LOGGED_OUT_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionHandler.TOKEN_LOGGED_OUT, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = tokenExceptionAdvice.tokenLoggedOutException(new TokenLoggedOutException());
+        CommonResult commonResult_KO = tokenExceptionHandler.tokenLoggedOutException(new TokenLoggedOutException());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = tokenExceptionAdvice.tokenLoggedOutException(new TokenLoggedOutException());
+        CommonResult commonResult_EN = tokenExceptionHandler.tokenLoggedOutException(new TokenLoggedOutException());
 
         // Then
         assertEquals(TOKEN_LOGGED_OUT_EXCEPTION_CODE_KO, TOKEN_LOGGED_OUT_EXCEPTION_CODE_EN);
@@ -133,15 +133,15 @@ public class TokenExceptionAdviceTest {
     void AuthorizationHeaderIsEmptyException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionAdvice.AUTHORIZATION_HEADER_IS_EMPTY, Locale.KOREA);
-        final int AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionAdvice.AUTHORIZATION_HEADER_IS_EMPTY, Locale.ENGLISH);
-        final String AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionAdvice.AUTHORIZATION_HEADER_IS_EMPTY, Locale.KOREA);
-        final String AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionAdvice.AUTHORIZATION_HEADER_IS_EMPTY, Locale.ENGLISH);
+        final int AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionHandler.AUTHORIZATION_HEADER_IS_EMPTY, Locale.KOREA);
+        final int AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionHandler.AUTHORIZATION_HEADER_IS_EMPTY, Locale.ENGLISH);
+        final String AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionHandler.AUTHORIZATION_HEADER_IS_EMPTY, Locale.KOREA);
+        final String AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionHandler.AUTHORIZATION_HEADER_IS_EMPTY, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = tokenExceptionAdvice.authorizationHeaderIsEmpty(new AuthorizationHeaderIsEmpty());
+        CommonResult commonResult_KO = tokenExceptionHandler.authorizationHeaderIsEmpty(new AuthorizationHeaderIsEmpty());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = tokenExceptionAdvice.authorizationHeaderIsEmpty(new AuthorizationHeaderIsEmpty());
+        CommonResult commonResult_EN = tokenExceptionHandler.authorizationHeaderIsEmpty(new AuthorizationHeaderIsEmpty());
 
         // Then
         assertEquals(AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_KO, AUTHORIZATION_HEADER_IS_EMPTY_EXCEPTION_CODE_EN);
@@ -159,15 +159,15 @@ public class TokenExceptionAdviceTest {
     void RefreshTokenHeaderIsEmptyException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionAdvice.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.KOREA);
-        final int REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionAdvice.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.ENGLISH);
-        final String REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionAdvice.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.KOREA);
-        final String REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionAdvice.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.ENGLISH);
+        final int REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_KO = getExceptionCode(TokenExceptionHandler.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.KOREA);
+        final int REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_EN = getExceptionCode(TokenExceptionHandler.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.ENGLISH);
+        final String REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_MSG_KO = getExceptionMsg(TokenExceptionHandler.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.KOREA);
+        final String REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_MSG_EN = getExceptionMsg(TokenExceptionHandler.REFRESH_TOKEN_HEADER_IS_EMPTY, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = tokenExceptionAdvice.refreshTokenIsEmpty(new RefreshTokenHeaderIsEmpty());
+        CommonResult commonResult_KO = tokenExceptionHandler.refreshTokenIsEmpty(new RefreshTokenHeaderIsEmpty());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = tokenExceptionAdvice.refreshTokenIsEmpty(new RefreshTokenHeaderIsEmpty());
+        CommonResult commonResult_EN = tokenExceptionHandler.refreshTokenIsEmpty(new RefreshTokenHeaderIsEmpty());
 
         // Then
         assertEquals(REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_KO, REFRESH_TOKEN_HEADER_IS_EMPTY_EXCEPTION_CODE_EN);

--- a/src/test/java/com/server/EZY/exception/UnknownExceptionHandlerTest.java
+++ b/src/test/java/com/server/EZY/exception/UnknownExceptionHandlerTest.java
@@ -2,7 +2,7 @@ package com.server.EZY.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.EZY.exception.unknownException.UnknownExceptionAdvice;
+import com.server.EZY.exception.unknownException.UnknownExceptionHandler;
 import com.server.EZY.response.result.CommonResult;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -21,11 +21,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @DisplayName("ExceptionAdvice test")
 @AutoConfigureMockMvc
-class UnknownExceptionAdviceTest {
+class UnknownExceptionHandlerTest {
 
     @Autowired ObjectMapper objMapper;
     @Autowired MessageSource messageSource;
-    @Autowired UnknownExceptionAdvice unknownExceptionAdvice;
+    @Autowired
+    UnknownExceptionHandler unknownExceptionHandler;
 
     // LocalContext의 locale을 변경한다.
     void setLocal(Locale locale){
@@ -52,16 +53,16 @@ class UnknownExceptionAdviceTest {
     void DefaultException_검증() throws Exception {
         // Given
         setLocal(Locale.KOREA);
-        final int DEFAULT_EXCEPTION_CODE_KO = getExceptionCode(UnknownExceptionAdvice.DEFAULT_EXCEPTION, Locale.KOREA);
-        final int USER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(UnknownExceptionAdvice.DEFAULT_EXCEPTION, Locale.ENGLISH);
+        final int DEFAULT_EXCEPTION_CODE_KO = getExceptionCode(UnknownExceptionHandler.DEFAULT_EXCEPTION, Locale.KOREA);
+        final int USER_NOT_FOUND_EXCEPTION_CODE_EN = getExceptionCode(UnknownExceptionHandler.DEFAULT_EXCEPTION, Locale.ENGLISH);
 
-        final String USER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(UnknownExceptionAdvice.DEFAULT_EXCEPTION, Locale.KOREA);
-        final String USER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(UnknownExceptionAdvice.DEFAULT_EXCEPTION, Locale.ENGLISH);
+        final String USER_NOT_FOUND_EXCEPTION_MSG_KO = getExceptionMsg(UnknownExceptionHandler.DEFAULT_EXCEPTION, Locale.KOREA);
+        final String USER_NOT_FOUND_EXCEPTION_MSG_EN = getExceptionMsg(UnknownExceptionHandler.DEFAULT_EXCEPTION, Locale.ENGLISH);
 
         // When
-        CommonResult commonResult_KO = unknownExceptionAdvice.defaultException(new Exception());
+        CommonResult commonResult_KO = unknownExceptionHandler.defaultException(new Exception());
         setLocal(Locale.ENGLISH);
-        CommonResult commonResult_EN = unknownExceptionAdvice.defaultException(new Exception());
+        CommonResult commonResult_EN = unknownExceptionHandler.defaultException(new Exception());
 
         // Then
         assertEquals(DEFAULT_EXCEPTION_CODE_KO, USER_NOT_FOUND_EXCEPTION_CODE_EN);


### PR DESCRIPTION
### 한 일
#### 모든 **ExceptionAdvice를 **ExceptionHandler로 이름변경 했습니다.
> ex. 
이유는 다음과 같습니다.  
1. 초기 ExceptionHandling방식은 `ExceptionAdvice`로 모든 Exception를 Handling하는 것입니다.  
`ExceptionAdvice`를 `ExceptionHandler`로 이름 변경을 하고 싶었지만 SpringBoot에서 이미 `ExceptionHandler`라는 이름의 Bean이 정의되어 있어서 하지 못했습니다.
2. 하지만 이제 Exception의 큰 범주별로 각각의`ExceptionAdvice`를 만들므로 위에서 언급된 Bean이름 중복문제가 해결되었습니다.
3. 그래서 가독성을 위해 **ExceptionAdvice대신 **ExceptionHandler로 이름을 변경했습니다.

#### exception 패키지 속 user 패키지를 member패키지로 변경했습니다.
저번에 우리 서비스는 user도메인을 member로 rename하는 작업을 진행했었지만 exception 패키지에서 누락되었습니다. 그래서 변경했습니다.

exception로직의 잦은 변경 죄송합니다. 
초반 설계를 제대로 신경 쓰지 못해 지금이라도 변경해야 나중에 복잡성을 피할 수 있어서 부득이하게 변경 횟수가 많아졌네요
바쁘신 와중 pr확인해주셔서 감사합니다. :)