### PR TITLE
startTime -> startDateTime, endTime -> endDateTime

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
+++ b/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
@@ -17,10 +17,10 @@ import java.util.Objects;
 public class Period {
 
     @Column(name = "start_time", nullable = false)
-    private LocalDateTime startTime;
+    private LocalDateTime startDateTime;
 
     @Column(name = "end_time", nullable = false)
-    private LocalDateTime endTime;
+    private LocalDateTime endDateTime;
 
     /**
      * Period객체를 업데이트 한다.
@@ -28,8 +28,8 @@ public class Period {
      * @author 정시원
      */
     public void updatePeriod(Period updatedPeriod){
-        this.startTime = updatedPeriod.startTime != null ? updatedPeriod.startTime : this.startTime;
-        this.endTime = updatedPeriod.endTime != null ? updatedPeriod.endTime : this.endTime;
+        this.startDateTime = updatedPeriod.startDateTime != null ? updatedPeriod.startDateTime : this.startDateTime;
+        this.endDateTime = updatedPeriod.endDateTime != null ? updatedPeriod.endDateTime : this.endDateTime;
     }
 
     @Override @Generated
@@ -37,11 +37,11 @@ public class Period {
         if (this == o) return true;
         if (!(o instanceof Period)) return false;
         Period period = (Period) o;
-        return Objects.equals(getStartTime(), period.getStartTime()) && Objects.equals(getEndTime(), period.getEndTime());
+        return Objects.equals(getStartDateTime(), period.getStartDateTime()) && Objects.equals(getEndDateTime(), period.getEndDateTime());
     }
 
     @Override @Generated
     public int hashCode() {
-        return Objects.hash(getStartTime(), getEndTime());
+        return Objects.hash(getStartDateTime(), getEndDateTime());
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
@@ -74,8 +74,8 @@ class ErrandTest {
                 .explanation("PersonalPlanService 끝내버려")
                 .build();
         Period period = Period.builder()
-                .startTime(LocalDateTime.of(20201, 7, 27, 17, 30))
-                .endTime(LocalDateTime.of(20201, 7, 27, 20, 30))
+                .startDateTime(LocalDateTime.of(20201, 7, 27, 17, 30))
+                .endDateTime(LocalDateTime.of(20201, 7, 27, 20, 30))
                 .build();
 
         ErrandEntity siwonErrand = ErrandEntity.builder()
@@ -127,8 +127,8 @@ class ErrandTest {
                 .explanation("PersonalPlanService 끝내버려")
                 .build();
         Period period = Period.builder()
-                .startTime(LocalDateTime.of(20201, 7, 27, 17, 30))
-                .endTime(LocalDateTime.of(20201, 7, 27, 20, 30))
+                .startDateTime(LocalDateTime.of(20201, 7, 27, 17, 30))
+                .endDateTime(LocalDateTime.of(20201, 7, 27, 20, 30))
                 .build();
 
         ErrandEntity siwonErrand = ErrandEntity.builder()

--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
@@ -50,8 +50,8 @@ class PersonalPlanEntityTest {
                 .build();
 
         Period period = Period.builder()
-                .startTime(LocalDateTime.of(2021, 7, 24, 1, 30))
-                .endTime(LocalDateTime.of(2021, 7, 24, 6, 30))
+                .startDateTime(LocalDateTime.of(2021, 7, 24, 1, 30))
+                .endDateTime(LocalDateTime.of(2021, 7, 24, 6, 30))
                 .build();
 
         Boolean repetition = true;
@@ -83,8 +83,8 @@ class PersonalPlanEntityTest {
                 .build();
 
         Period period = Period.builder()
-                .startTime(LocalDateTime.of(2021, 7, 24, 1, 30))
-                .endTime(LocalDateTime.of(2021, 7, 24, 6, 30))
+                .startDateTime(LocalDateTime.of(2021, 7, 24, 1, 30))
+                .endDateTime(LocalDateTime.of(2021, 7, 24, 6, 30))
                 .build();
 
         Boolean repetition = true;


### PR DESCRIPTION
### 한 일
저희는 date + time을 저장하는 LocalDateTime을 사용하므로 가독성을 위해 Period객체의 필드이름을 다음과 같이 변경했습니다
Period객체의 startTime의 변수명을 startDateTime로 변경했습니다.
Period객체의 endTime의 변수명을 endDateTime로 변경했습니다.

실수로 branch를 나누지 않고 작업을 진행했네요 :( 어차피 변경사항도 없으니 그냥 pr날려요