### PR TITLE
Exception헨들링 누락(405 해결)

### DIFF
--- a/src/main/java/com/server/EZY/exception/unknownException/UnknownExceptionHandler.java
+++ b/src/main/java/com/server/EZY/exception/unknownException/UnknownExceptionHandler.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -18,6 +21,8 @@ public class UnknownExceptionHandler {
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 
     // 알수없는 에러
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public CommonResult defaultException(Exception ex){
         log.error("=== 알 수 없는 애러 발생 ===", ex);
         return exceptionResponseObjectUtil.getExceptionResponseObj(DEFAULT_EXCEPTION);


### PR DESCRIPTION
### 한 일
####  `UnknownExceptionHandler`의 `defaultException`에 `ExceptionHandler`를 누락 해결
다음을 누락해 console에 예외처리를 하지못한 모든 Exception들이 console에 출력되지도 않고 ResponseBody가 나타나지 않는 버그가 발생했습니다 
개발에 혼선을드려 죄송합니다 😭