### PR TITLE
개인일정조회 - startTime 만 requestParam 으로 넘겼을 때 조건 성공!

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
+++ b/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
@@ -19,11 +19,11 @@ import java.util.Objects;
 public class Period {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    @Column(name = "start_time", nullable = false)
+    @Column(name = "start_date_time", nullable = false)
     private LocalDateTime startDateTime;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    @Column(name = "end_time", nullable = false)
+    @Column(name = "end_date_time", nullable = false)
     private LocalDateTime endDateTime;
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
+++ b/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
@@ -18,11 +18,11 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class Period {
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "start_time", nullable = false)
     private LocalDateTime startDateTime;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endDateTime;
 

--- a/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
+++ b/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
@@ -18,11 +18,11 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class Period {
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "start_time", nullable = false)
     private LocalDateTime startDateTime;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endDateTime;
 

--- a/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
+++ b/src/main/java/com/server/EZY/model/plan/embeddedTypes/Period.java
@@ -1,6 +1,8 @@
 package com.server.EZY.model.plan.embeddedTypes;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -16,9 +18,11 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class Period {
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "start_time", nullable = false)
     private LocalDateTime startDateTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endDateTime;
 

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -40,7 +40,7 @@ public class PersonalPlanController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult getThisPersonalPlan(@PathVariable Long planIdx){
+    public CommonResult getThisPersonalPlan(@PathVariable("planIdx") Long planIdx){
         return responseService.getSingleResult(personalPlanService.getThisPersonalPlan(planIdx));
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -37,15 +37,16 @@ public class PersonalPlanController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult getAllPersonalPlan(
-            @RequestParam(value = "startDateTime", required = false)@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDateTimeOrNull,
-            @RequestParam(value = "endDateTime", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDateTimeOrNull
+            @RequestParam(value = "startDate", required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime startDateOrNull,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime endDateOrNull
     ){
-        if (startDateTimeOrNull != null){
-            return responseService.getListResult(personalPlanService.getThisStartDateTimePersonalEntities(startDateTimeOrNull));
+        log.debug("======{}======", startDateOrNull);
+        if (startDateOrNull != null){
+            return responseService.getListResult(personalPlanService.getThisStartDateTimePersonalEntities(startDateOrNull));
         }
 //        else if(endDateTimeOrNull != null){
 //            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-//        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!=null){
+//        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!r=null){
 //            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
 //        }
         else{

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -42,6 +42,8 @@ public class PersonalPlanController {
             return responseService.getListResult(personalPlanService.getAllPersonalPlan());
         } else if(endDateTimeOrNull != null){
             return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!=null){
+            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
         } else{
             return responseService.getListResult(personalPlanService.getAllPersonalPlan());
         }

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -7,6 +7,7 @@ import com.server.EZY.response.result.CommonResult;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -34,8 +35,8 @@ public class PersonalPlanController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult getAllPersonalPlan(
-            @RequestParam(value = "startDateTime", required = false)LocalDateTime startDateTimeOrNull,
-            @RequestParam(value = "endDateTime", required = false)LocalDateTime endDateTimeOrNull
+            @RequestParam(value = "startDateTime", required = false)@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDateTimeOrNull,
+            @RequestParam(value = "endDateTime", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTimeOrNull
     ){
         return responseService.getListResult(personalPlanService.getAllPersonalPlan());
     }

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -9,6 +9,8 @@ import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/v1/plan/personal")
 @RequiredArgsConstructor
@@ -31,7 +33,10 @@ public class PersonalPlanController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult getAllPersonalPlan(){
+    public CommonResult getAllPersonalPlan(
+            @RequestParam(value = "startDateTime", required = false)LocalDateTime startDateTimeOrNull,
+            @RequestParam(value = "endDateTime", required = false)LocalDateTime endDateTimeOrNull
+    ){
         return responseService.getListResult(personalPlanService.getAllPersonalPlan());
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -7,11 +7,13 @@ import com.server.EZY.response.result.CommonResult;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @RestController
 @RequestMapping("/v1/plan/personal")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -37,8 +38,8 @@ public class PersonalPlanController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult getAllPersonalPlan(
-            @RequestParam(value = "startDate", required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime startDateOrNull,
-            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime endDateOrNull
+            @RequestParam(value = "startDate", required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDateOrNull,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDateOrNull
     ){
         log.debug("======{}======", startDateOrNull);
         if (startDateOrNull != null){

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -39,12 +39,14 @@ public class PersonalPlanController {
             @RequestParam(value = "endDateTime", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDateTimeOrNull
     ){
         if (startDateTimeOrNull != null){
-            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-        } else if(endDateTimeOrNull != null){
-            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!=null){
-            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-        } else{
+            return responseService.getListResult(personalPlanService.getThisStartDateTimePersonalEntities(startDateTimeOrNull));
+        }
+//        else if(endDateTimeOrNull != null){
+//            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+//        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!=null){
+//            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+//        }
+        else{
             return responseService.getListResult(personalPlanService.getAllPersonalPlan());
         }
     }

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -36,9 +36,15 @@ public class PersonalPlanController {
     })
     public CommonResult getAllPersonalPlan(
             @RequestParam(value = "startDateTime", required = false)@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDateTimeOrNull,
-            @RequestParam(value = "endDateTime", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTimeOrNull
+            @RequestParam(value = "endDateTime", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDateTimeOrNull
     ){
-        return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        if (startDateTimeOrNull != null){
+            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        } else if(endDateTimeOrNull != null){
+            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        } else{
+            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        }
     }
 
     @GetMapping("/{planIdx}")

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -41,16 +41,14 @@ public class PersonalPlanController {
             @RequestParam(value = "startDate", required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDateOrNull,
             @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDateOrNull
     ){
-        log.debug("======{}======", startDateOrNull);
-        if (startDateOrNull != null){
+        log.debug("====it's startDateOrNull======{}======", startDateOrNull);
+        log.debug("=====it's endDateOrNull====={}======", endDateOrNull);
+
+        if (startDateOrNull != null && endDateOrNull == null){
             return responseService.getListResult(personalPlanService.getThisStartDateTimePersonalEntities(startDateOrNull));
-        }
-//        else if(endDateTimeOrNull != null){
-//            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-//        } else if(startDateTimeOrNull!=null && endDateTimeOrNull!r=null){
-//            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
-//        }
-        else{
+        } else if(startDateOrNull!=null && endDateOrNull != null){
+            return responseService.getListResult(personalPlanService.getAllPersonalPlan());
+        } else{
             return responseService.getListResult(personalPlanService.getAllPersonalPlan());
         }
     }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
@@ -3,9 +3,11 @@ package com.server.EZY.model.plan.personal.repository;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PersonalPlanRepoCustom {
     List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
+    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(MemberEntity memberEntity, LocalDateTime startDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface PersonalPlanRepoCustom {
     List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
-    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDate startDate);
+    List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface PersonalPlanRepoCustom {
     List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
-    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(MemberEntity memberEntity, LocalDateTime startDateTime);
+    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDateTime startDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoCustom.java
@@ -3,11 +3,12 @@ package com.server.EZY.model.plan.personal.repository;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PersonalPlanRepoCustom {
     List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
-    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDateTime startDateTime);
+    List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDate startDate);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -27,10 +27,6 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
     @Override
     public List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
             MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-
-        log.debug("====== it's personalPlan startTime: {}=========",
-                personalPlanEntity.period.startDateTime);
-
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -6,12 +6,12 @@ import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import static com.server.EZY.model.plan.personal.QPersonalPlanEntity.personalPlanEntity;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
 
@@ -25,12 +25,17 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
     }
 
     @Override
-    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDate startDate) {
+    public List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
+            MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+        log.debug("====== it's personalPlan startTime: {}=========",
+                personalPlanEntity.period.startDateTime);
+
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(
                         personalPlanEntity.memberEntity.eq(memberEntity),
-                        personalPlanEntity.period.startDateTime.between(startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX))
+                        personalPlanEntity.period.startDateTime.between(startDateTime, endDateTime)
                 ).fetch();
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -28,7 +28,7 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
                 .selectFrom(personalPlanEntity)
                 .where(
                         personalPlanEntity.memberEntity.eq(memberEntity),
-                        personalPlanEntity.period.startTime.eq(startDateTime)
+                        personalPlanEntity.period.startDateTime.eq(startDateTime)
                 ).fetch();
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -23,7 +23,7 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
     }
 
     @Override
-    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(MemberEntity memberEntity, LocalDateTime startDateTime) {
+    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDateTime startDateTime) {
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -7,7 +7,9 @@ import static com.server.EZY.model.plan.personal.QPersonalPlanEntity.personalPla
 
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -23,12 +25,12 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
     }
 
     @Override
-    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDateTime startDateTime) {
+    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(MemberEntity memberEntity, LocalDate startDate) {
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(
                         personalPlanEntity.memberEntity.eq(memberEntity),
-                        personalPlanEntity.period.startDateTime.eq(startDateTime)
+                        personalPlanEntity.period.startDateTime.between(startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX))
                 ).fetch();
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepoImpl.java
@@ -7,6 +7,7 @@ import static com.server.EZY.model.plan.personal.QPersonalPlanEntity.personalPla
 
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -19,6 +20,16 @@ public class PersonalPlanRepoImpl implements PersonalPlanRepoCustom{
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(personalPlanEntity.memberEntity.eq(memberEntity)).fetch();
+    }
+
+    @Override
+    public List<PersonalPlanEntity> findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(MemberEntity memberEntity, LocalDateTime startDateTime) {
+        return jpaQueryFactory
+                .selectFrom(personalPlanEntity)
+                .where(
+                        personalPlanEntity.memberEntity.eq(memberEntity),
+                        personalPlanEntity.period.startTime.eq(startDateTime)
+                ).fetch();
     }
 
     @Override

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepository.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanRepository.java
@@ -3,5 +3,7 @@ package com.server.EZY.model.plan.personal.repository;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PersonalPlanRepository extends JpaRepository<PersonalPlanEntity, Long>, PersonalPlanRepoCustom {
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -3,13 +3,14 @@ package com.server.EZY.model.plan.personal.service;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import com.server.EZY.model.plan.personal.dto.PersonalPlanSetDto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PersonalPlanService {
     PersonalPlanEntity createPersonalPlan(PersonalPlanSetDto personalPlanSetDto);
     List<PersonalPlanEntity> getAllPersonalPlan();
-    List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDateTime startDateTime);
+    List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDate startDate);
     PersonalPlanEntity getThisPersonalPlan(Long planIdx);
     void deleteThisPersonalPlan(Long planIdx);
     PersonalPlanEntity updateThisPersonalPlan(Long planIdx, PersonalPlanSetDto personalPlanSetDto) throws Exception;

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface PersonalPlanService {
     PersonalPlanEntity createPersonalPlan(PersonalPlanSetDto personalPlanSetDto);
     List<PersonalPlanEntity> getAllPersonalPlan();
-    List<PersonalPlanEntity> getThisStartDateTime(LocalDateTime startDateTime);
+    List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDateTime startDateTime);
     PersonalPlanEntity getThisPersonalPlan(Long planIdx);
     void deleteThisPersonalPlan(Long planIdx);
     PersonalPlanEntity updateThisPersonalPlan(Long planIdx, PersonalPlanSetDto personalPlanSetDto) throws Exception;

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -3,11 +3,13 @@ package com.server.EZY.model.plan.personal.service;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import com.server.EZY.model.plan.personal.dto.PersonalPlanSetDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PersonalPlanService {
     PersonalPlanEntity createPersonalPlan(PersonalPlanSetDto personalPlanSetDto);
     List<PersonalPlanEntity> getAllPersonalPlan();
+    List<PersonalPlanEntity> getThisStartDateTime(LocalDateTime startDateTime);
     PersonalPlanEntity getThisPersonalPlan(Long planIdx);
     void deleteThisPersonalPlan(Long planIdx);
     PersonalPlanEntity updateThisPersonalPlan(Long planIdx, PersonalPlanSetDto personalPlanSetDto) throws Exception;

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -51,9 +52,9 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
     }
 
     @Override
-    public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDateTime startDateTime) {
+    public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDate startDate) {
         MemberEntity currentUser = userUtil.getCurrentUser();
-        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(currentUser, startDateTime);
+        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(currentUser, startDate);
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -9,13 +9,16 @@ import com.server.EZY.model.plan.tag.TagEntity;
 import com.server.EZY.model.plan.tag.repository.TagRepository;
 import com.server.EZY.util.CurrentUserUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PersonalPlanServiceImpl implements PersonalPlanService{
@@ -54,6 +57,10 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
     @Override
     public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDate startDate) {
         MemberEntity currentUser = userUtil.getCurrentUser();
+        log.debug("==this is currentUser====={}==========", currentUser);
+        log.debug("==this is startDate====={}==========", startDate);
+        log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
+        log.debug("====== this is startDate atEndOfDay: {}==========", startDate.atTime(LocalTime.MAX));
         return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(currentUser, startDate);
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -53,7 +53,7 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
     @Override
     public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDateTime startDateTime) {
         MemberEntity currentUser = userUtil.getCurrentUser();
-        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(currentUser, startDateTime);
+        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(currentUser, startDateTime);
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -56,8 +56,6 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
     @Override
     public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDate startDate) {
         MemberEntity currentUser = userUtil.getCurrentUser();
-        log.debug("==this is currentUser====={}==========", currentUser);
-        log.debug("==this is startDate====={}==========", startDate);
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is startDate atEndOfDay: {}==========", startDate.atTime(LocalTime.MAX));
         return personalPlanRepository.findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -61,7 +60,8 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
         log.debug("==this is startDate====={}==========", startDate);
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is startDate atEndOfDay: {}==========", startDate.atTime(LocalTime.MAX));
-        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartDateTime(currentUser, startDate);
+        return personalPlanRepository.findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
+                currentUser, startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX));
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -47,6 +48,12 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
     public List<PersonalPlanEntity> getAllPersonalPlan() {
         MemberEntity currentUser = userUtil.getCurrentUser();
         return personalPlanRepository.findAllPersonalPlanByMemberEntity(currentUser);
+    }
+
+    @Override
+    public List<PersonalPlanEntity> getThisStartDateTimePersonalEntities(LocalDateTime startDateTime) {
+        MemberEntity currentUser = userUtil.getCurrentUser();
+        return personalPlanRepository.findAllPersonalPlanEntitiesByMemberEntityAndPeriodStartTime(currentUser, startDateTime);
     }
 
     /**


### PR DESCRIPTION
## if (startDateOrNull != null && endDateOrNull == null) 을 만족시킨 PR 입니다.
개인일정조회 `requestParam` 은 아직 끝나지 않았습니다.
하지만, 현재 변경사항이 많아져 코드리뷰의 집중도를 높이기 위해 하나의 조건만 PR 합니다.

### 이부분이 변경 됐어요!
1. period `startDateTime` , `endDateTime` 의 **@JsonFormat**
<img width="761" alt="Screen Shot 2021-08-04 at 6 45 23 PM" src="https://user-images.githubusercontent.com/67095821/128159994-834d68e3-fc43-4c1b-b5de-eb53694ca08f.png">

2. 디스코드에 공지했던 조건들에서 변경이 생겼어요.
> `PersonalPlanController/getAllPersonalPlan` 참고하세요~ (메서드 네임 확정된거 아닙니다)
> if `startTime 만 입력했을 때, 그 날짜의 일정들만 조회`, else if `startTime, endTime 둘 다 입력 시, 기간 내 조회`, else `전체조회`
<img width="422" alt="Screen Shot 2021-08-04 at 6 46 55 PM" src="https://user-images.githubusercontent.com/67095821/128160220-62b3f678-31b0-408d-954c-2d3fe5605e05.png">

### 리뷰 부탁드립니다.
1. 변경사항이 많고 애도 많이 먹어서 변수명이 준구난방입니다.
> 이부분은 제가 수정 예정이지만, 리뷰어분들도 같이 찾아(제안)주셨으면 감사하겠습니다 🙇🏻‍♂️

2. 변경된 조건이 어떠한가요? 
3. 쓸모 없는 필드 들이 존재하나요?
