### PR TITLE
PersonalPlanEntity_생성_조회_삭제_테스트 실패 해결

### DIFF
--- a/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/PersonalPlanEntityTest.java
@@ -1,6 +1,5 @@
 package com.server.EZY.model.plan.personal;
 
-import com.server.EZY.exception.user.exception.InvalidAccessException;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
@@ -8,6 +7,7 @@ import com.server.EZY.model.plan.embeddedTypes.Period;
 import com.server.EZY.model.plan.embeddedTypes.PlanInfo;
 import com.server.EZY.model.plan.personal.repository.PersonalPlanRepository;
 import com.server.EZY.model.plan.tag.TagEntity;
+import com.server.EZY.model.plan.tag.embeddedTypes.Color;
 import com.server.EZY.model.plan.tag.repository.TagRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +74,7 @@ class PersonalPlanEntityTest {
         TagEntity tagEntity = TagEntity.builder()
                 .memberEntity(savedMemberEntity)
                 .tag("공부")
+                .color(new Color((short)125, (short)125, (short)125))
                 .build();
         TagEntity savedTagEntity = tagRepository.getById(tagRepository.save(tagEntity).getTagIdx());
 


### PR DESCRIPTION
### 원인
`TagEntity`에 `Color`컬럼이 추가되어  생겼던 오류였습니다. `Color`속 필드는 모두 `notNull`입니다!

### build결과
Test는 모두 통과했지만 테스트 커버리지에서 막히네요
![image](https://user-images.githubusercontent.com/62932968/128623309-5e1d7359-bbc1-4e96-ae5c-06a6c812d146.png)
