### PR TITLE
repository, embeddedType 패키지의 하위 코드를 Jacoco테스트 커버리지에서 제외함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,8 @@ jacocoTestReport {
 			fileTree(dir: it, exclude: [
 					'**/exception/**'
 					,'**/dto/**'
+					,'**/repository/**' // DAO(repository)
+					,'**/embeddedTypes/**' //embeddedTypes 제거
 					,'**/EZY/EzyApplication*'
 					,'**/EZY/**/*Test*'
 					,'**/EZY/**/Q*' // Q class 제거


### PR DESCRIPTION
### 한 일
#### repository, embeddedType 패키지의 하위 코드를 Jacoco테스트 커버리지에서 제외했습니다.

### BUILD 결과
![image](https://user-images.githubusercontent.com/62932968/128704655-00afd2b7-4926-409c-93c4-dbdfb59d6039.png)

아마 0%달성한 로직에 대해 테스트 코드를 진행해야 build가 성공 할 거 같아요
