### PR TITLE
Feature/personal plan controller test - save personalPlan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
 
 	// *** lombok *** //
 	implementation 'org.projectlombok:lombok'

--- a/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
@@ -2,7 +2,6 @@ package com.server.EZY.model.plan.personal.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.EZY.model.member.MemberEntity;
-import com.server.EZY.model.member.controller.jwt.RefreshTokenController;
 import com.server.EZY.model.member.dto.MemberDto;
 import com.server.EZY.model.member.enumType.Role;
 import com.server.EZY.model.member.repository.MemberRepository;

--- a/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PersonalPlanControllerTest {
+  
+}

--- a/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
@@ -1,20 +1,101 @@
 package com.server.EZY.model.plan.personal.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.EZY.model.member.MemberEntity;
+import com.server.EZY.model.member.controller.jwt.RefreshTokenController;
+import com.server.EZY.model.member.dto.MemberDto;
+import com.server.EZY.model.member.enumType.Role;
+import com.server.EZY.model.member.repository.MemberRepository;
+import com.server.EZY.model.plan.embeddedTypes.Period;
+import com.server.EZY.model.plan.embeddedTypes.PlanInfo;
+import com.server.EZY.model.plan.personal.dto.PersonalPlanSetDto;
 import com.server.EZY.testConfig.AbstractControllerTest;
+import com.server.EZY.util.CurrentUserUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 @SpringBootTest
 @Transactional
 class PersonalPlanControllerTest extends AbstractControllerTest {
     @Autowired
     private PersonalPlanController personalPlanController;
+    @Autowired
+    private RefreshTokenController refreshTokenController;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ObjectMapper mapper;
+
+    MemberEntity savedMemberEntity;
+    @BeforeEach @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
+    void GetUserEntity(){
+        //Given
+        MemberDto memberDto = MemberDto.builder()
+                .username("배태현")
+                .password("1234")
+                .phoneNumber("01012341234")
+                .build();
+
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
+        savedMemberEntity = memberRepository.save(memberDto.toEntity());
+        System.out.println("======== saved =========");
+
+        // when login session 발급
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto.getUsername(),
+                memberDto.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_CLIENT.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println("=================================");
+        System.out.println(context);
+
+        //then
+        String currentUserNickname = CurrentUserUtil.getCurrentUsername();
+        assertEquals("배태현", currentUserNickname);
+    }
 
     @Override
     protected Object controller() {
         return personalPlanController;
+    }
+
+    @Test
+    public void savePersonalPlan() throws Exception {
+        PersonalPlanSetDto personalPlanSetDto = PersonalPlanSetDto.builder()
+                .planInfo(new PlanInfo("와우껌", "좋아요", "광주광역시"))
+                .period(new Period(
+                                LocalDateTime.of(2021, 7, 24, 1, 30),
+                                LocalDateTime.of(2021, 7, 24, 1, 30)
+                        )
+                )
+                .tagIdx(1L)
+                .repetition(false)
+                .build();
+
+        mvc.perform(
+                post("/v1/plan/personal")
+                .content(mapper.writeValueAsString(personalPlanSetDto))
+                .contentType(MediaType.APPLICATION_JSON)
+        );
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
@@ -1,4 +1,20 @@
+package com.server.EZY.model.plan.personal.controller;
+
+import com.server.EZY.testConfig.AbstractControllerTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
 import static org.junit.jupiter.api.Assertions.*;
-class PersonalPlanControllerTest {
-  
+
+@SpringBootTest
+@Transactional
+class PersonalPlanControllerTest extends AbstractControllerTest {
+    @Autowired
+    private PersonalPlanController personalPlanController;
+
+    @Override
+    protected Object controller() {
+        return personalPlanController;
+    }
 }

--- a/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/controller/PersonalPlanControllerTest.java
@@ -1,6 +1,5 @@
 package com.server.EZY.model.plan.personal.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.controller.jwt.RefreshTokenController;
@@ -36,8 +35,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 class PersonalPlanControllerTest extends AbstractControllerTest {
     @Autowired
     private PersonalPlanController personalPlanController;
-    @Autowired
-    private RefreshTokenController refreshTokenController;
     @Autowired
     private PasswordEncoder passwordEncoder;
     @Autowired

--- a/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
+++ b/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
@@ -1,0 +1,33 @@
+package com.server.EZY.testConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@SpringBootTest
+public abstract class AbstractControllerTest {
+    protected MockMvc mvc;
+
+    abstract protected Object controller();
+
+    /**
+     * MockMvcBuilders 를 활용한 MockMvc 커스텀 메서드
+     * 1. addFilter: UTF-8 인코딩을 해주지 않으면 테스트 수행 시 body가 깨진다.
+     * 2. alwaysDo: 항상 콘솔에 테스트 결과를 찍어줘라.
+     *
+     * @author: 전지환
+     */
+    @BeforeEach
+    private void setup(){
+        mvc = MockMvcBuilders.standaloneSetup(controller())
+                .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+                .alwaysDo(print())
+                .build();
+    }
+}

--- a/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
+++ b/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import java.nio.charset.StandardCharsets;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 public abstract class AbstractControllerTest {
@@ -28,6 +29,7 @@ public abstract class AbstractControllerTest {
         mvc = MockMvcBuilders.standaloneSetup(controller())
                 .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
                 .alwaysDo(print())
+                .alwaysExpect(status().isOk())
                 .build();
     }
 }

--- a/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
+++ b/src/test/java/com/server/EZY/testConfig/AbstractControllerTest.java
@@ -21,6 +21,7 @@ public abstract class AbstractControllerTest {
      * MockMvcBuilders 를 활용한 MockMvc 커스텀 메서드
      * 1. addFilter: UTF-8 인코딩을 해주지 않으면 테스트 수행 시 body가 깨진다.
      * 2. alwaysDo: 항상 콘솔에 테스트 결과를 찍어줘라.
+     * 3. alwaysExpect: 항상 200 코드를 반환하기를 기대한다.
      *
      * @author: 전지환
      */


### PR DESCRIPTION
## MockMvc 기본 환경 설정 및 controller/savePersonalPlan 200 ok

### 이렇게 했습니다.
1. testConfig/AbstractControllerTest 를 추가하여 MockMvc 테스트 편의를 증가시킴 (주석 참고)
2. LocalDateTime json 직렬화 문제로 `build.gradle` 에 `testImplementation/jackson-datatype-jsr310:2.12.3` 추가

### 이렇게 해주세요
1. 테스트를 원하는 controller 에 extends `SomethingControllerTest extends AbstractControllerTest`
2. 자세한 사용방법은 code line **92-95** 참고하세요.
3. Test 시 `@BeforeEach` 로 세션 발급 로직 추가 해주시면 따로 header 검증 필요 없습니다 !

### 리뷰 부탁합니다
1. 제가 만든 AbstractControllerTest 에 대한 질문
2. 전체적인 TestWorkFlow 확인 

<img width="502" alt="Screen Shot 2021-08-14 at 6 23 12 PM" src="https://user-images.githubusercontent.com/67095821/129441382-27320491-d150-4d60-b780-df21d131284a.png">
