### PR TITLE
[UPDATE] refresh service test 보완

### DIFF
--- a/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
@@ -39,8 +39,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         MemberEntity findUser = memberRepository.findByUsername(nickname);
         List<Role> roles = findUser.getRoles();
 
-        if (redisUtil.getData(nickname) == null) throw new TokenLoggedOutException();
-
         if (redisUtil.getData(nickname).equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)) {
             redisUtil.deleteData(nickname);//refreshToken이 저장되어있는 레디스 초기화 후
 


### PR DESCRIPTION
### 제가 한 일이에요 !
<img width="354" alt="스크린샷 2021-08-15 오전 4 09 32" src="https://user-images.githubusercontent.com/69895394/129457829-e80bb4fa-8a96-4e88-9bbf-d34d243424f3.png">

`refreshTokenService` 로직에서 `else` 부문이 제대로 검증되지 않아 추가로 검증함으로 **100%** 달성했습니다 ! 

### 삭제됬어요 !
테스트를 하다가 `if (redisUtil.getData(nickname) == null) throw new TokenLoggedOutException();` 
이 부분은 애초에 `redisUtil.getData(nickname) == null` 조건이 적합하지 않고
`redis`에서 Key(nickname)로 **찾을수 없다면 다른 예외가 발생하는걸 확인**하고 삭제했습니다 !