### PR TITLE
[UPDATE] member service test

### DIFF
--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -73,8 +73,10 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public Map<String, String> signin(AuthDto loginDto) {
         MemberEntity memberEntity = memberRepository.findByUsername(loginDto.getUsername());
+        if (memberEntity == null) throw new MemberNotFoundException();
+
         boolean passwordCheck = passwordEncoder.matches(loginDto.getPassword(), memberEntity.getPassword());
-        if (memberEntity == null || !passwordCheck) throw new MemberNotFoundException();
+        if (!passwordCheck) throw new MemberNotFoundException();
 
         String accessToken = jwtTokenProvider.createToken(loginDto.getUsername(), loginDto.toEntity().getRoles());
         String refreshToken = jwtTokenProvider.createRefreshToken();

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -224,6 +224,6 @@ public class MemberServiceImpl implements MemberService {
 
         if (passwordEncoder.matches(deleteUserDto.getPassword(), memberEntity.getPassword())) {
             memberRepository.deleteById(memberEntity.getMemberIdx());
-        }
+        } else throw new MemberNotFoundException();
     }
 }

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -353,6 +353,30 @@ public class MemberServiceTest {
         assertTrue(catchException);
     }
 
+    @Test
+    public void deleteUserException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.deleteUser(
+                        AuthDto.builder()
+                                .username("NoUser")
+                                .password("5678")
+                                .build()
+                )
+        );
+
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.deleteUser(
+                        AuthDto.builder()
+                                .username("@Baetaehyeon")
+                                .password("0000")
+                                .build()
+                )
+        );
+    }
+
     /**
      * 로그인이 되어있는 유저를 만들기위해 뺀 메서드
      * @return loginUser(현재 로그인되어있는 유저)

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.server.EZY.model.member.service;
 
 import com.server.EZY.exception.user.exception.MemberAlreadyExistException;
+import com.server.EZY.exception.user.exception.MemberNotFoundException;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.controller.MemberController;
 import com.server.EZY.model.member.dto.*;
@@ -126,6 +127,20 @@ public class MemberServiceTest {
         Map<String, String> signin = memberService.signin(loginDto);
         //then
         assertTrue(true, String.valueOf(signin != null));
+    }
+
+    @Test
+    public void signinException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.signin(
+                        AuthDto.builder()
+                                .username(currentUser().getUsername())
+                                .password("0809")
+                                .build()
+                )
+        );
     }
 
     @Test

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -186,6 +186,15 @@ public class MemberServiceTest {
     }
 
     @Test
+    public void findUsernameException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.findUsername("NoUser")
+        );
+    }
+
+    @Test
     @DisplayName("Username 변경 테스트")
     public void changeUsername() {
         //given

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -142,6 +142,16 @@ public class MemberServiceTest {
                                 .build()
                 )
         );
+
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.signin(
+                        AuthDto.builder()
+                                .username("NoUser")
+                                .password("0809")
+                                .build()
+                )
+        );
     }
 
     @Test

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.server.EZY.model.member.service;
 
+import com.server.EZY.exception.user.exception.MemberAlreadyExistException;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.controller.MemberController;
 import com.server.EZY.model.member.dto.*;
@@ -83,6 +84,23 @@ public class MemberServiceTest {
 
         //then
         assertEquals("@BaeTul", memberEntity.getUsername());
+    }
+
+    @Test
+    @DisplayName("이미 회원가입된 유저입니다 Exception을 반환하는 테스트")
+    public void signupException() {
+        //given
+        MemberDto memberDto = MemberDto.builder()
+                .username(currentUser().getUsername())
+                .password("0809")
+                .phoneNumber("01008090809")
+                .build();
+
+        //when //then
+        assertThrows(
+                MemberAlreadyExistException.class,
+                () -> memberService.signup(memberDto)
+        );
     }
 
     @BeforeEach

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -186,6 +186,7 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("회원가입된 유저가 아닐 때 Exception이 터지나요?")
     public void findUsernameException() {
         //given //when //then
         assertThrows(

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -130,6 +130,7 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("비밀번호가 일치하지 않는다면 Exception이 터지나요?")
     public void signinException() {
         //given //when //then
         assertThrows(

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -304,6 +304,21 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("changePhoneNumber에서 MemberNotFoundException이 터지나요?")
+    public void changePhoneNumberException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.changePhoneNumber(
+                        PhoneNumberChangeDto.builder()
+                                .username("NoUser")
+                                .newPhoneNumber("01013131313")
+                                .build()
+                )
+        );
+    }
+
+    @Test
     @DisplayName("회원탈퇴 테스트")
     public void deleteMemberTest() {
         //given

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -263,6 +263,7 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("찾을 수 없는 user Exception이 터지나요?")
     public void changePasswordException() {
         //given //when //then
         assertThrows(

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -222,6 +222,21 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("memberEntity가 null이라면 MemberNotFoundException이 터지나요?")
+    public void changeUsernameException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.changeUsername(
+                        UsernameChangeDto.builder()
+                                .username("NoUser")
+                                .newUsername("@qoxogus")
+                                .build()
+                )
+        );
+    }
+
+    @Test
     @DisplayName("비밀번호 변경 테스트")
     public void changePasswordTest() {
         //given

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -263,6 +263,20 @@ public class MemberServiceTest {
     }
 
     @Test
+    public void changePasswordException() {
+        //given //when //then
+        assertThrows(
+                MemberNotFoundException.class,
+                () -> memberService.changePassword(
+                        PasswordChangeDto.builder()
+                                .username("NoUser")
+                                .newPassword("0000")
+                                .build()
+                )
+        );
+    }
+
+    @Test
     @DisplayName("전화번호 변경 테스트")
     public void changePhoneNumberTest() {
         //given

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -354,6 +354,7 @@ public class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("deleteUser에서 MemberNotFoundException이 잘 터지나요?")
     public void deleteUserException() {
         //given //when //then
         assertThrows(


### PR DESCRIPTION
### 제가 한 일이에요 !
* memberServiceTest 보완 (대부분 Exception이 잘 터지는지 검증했습니다 -> 테스트커버리지가 올라갔습니다)
* 회원탈퇴로직에서 else문이 누락되어 조건에 맞지않아도 Exception이 터지지않아 else문을 추가했습니다.

> 예전 **Member**의 **signin**로직에서 
조건문을 하나로 합쳤었는데 이번에 검증하려고 테스트코드를 짜다보니
**null인 memberEntity를 조건문에서 검사하는 것 보다 먼저 호출**하여 
저희가 원하는 `Exception`이 아닌 `NullPointerException`이 터지는걸 확인하여 
**조건문을 다시 2개로 나누었습니다.**

현재 `MemberService`에서 테스트되지 않은 로직들은 **메세지전송 관련 로직**입니다.

### 메세지전송 관련 해야할 일
> 070번호, coolsms연결

![스크린샷 2021-08-23 오전 11 32 57](https://user-images.githubusercontent.com/69895394/130382034-ddc62e20-ec28-4933-bb29-2d6f90fd6621.png)