### PR TITLE
MessageConfiguration 주석 추가 및 패키지명 변경

### DIFF
--- a/src/main/java/com/server/EZY/config/exception/MessageConfiguration.java
+++ b/src/main/java/com/server/EZY/config/exception/MessageConfiguration.java
@@ -18,25 +18,46 @@ import java.util.ResourceBundle;
 @Configuration
 public class MessageConfiguration implements WebMvcConfigurer {
 
-    @Bean // 세션 지역설정
+    /**
+     * 기본적으로 세션을 한국으로 설정한다
+     * @return sessionLocaleResolver - 세션의 지역정보를 한국으로 설정한 객체
+     * @author 정시원
+     */
+    @Bean
     public SessionLocaleResolver sessionLocalResolver(){
         SessionLocaleResolver sessionLocaleResolver = new SessionLocaleResolver();
         sessionLocaleResolver.setDefaultLocale(Locale.KOREAN);
         return sessionLocaleResolver;
     }
 
-    @Bean // 지역설정을 변경하는 인터셉터.
+    /**
+     * Request의 Locale 정보에 의해 Locale을 변경한 객체(LocaleChangeInterceptor)를 반환한다.
+     * @return LocaleChangeInterceptor
+     * @author 정시원
+     */
+    @Bean
     public LocaleChangeInterceptor localeChangeInterceptor(){
         LocaleChangeInterceptor localeChangeInterceptor = new LocaleChangeInterceptor();
         localeChangeInterceptor.setParamName("lang");
         return localeChangeInterceptor;
     }
 
-    @Override // 인터셉터를 시스템 레지스트리에 등록
+    /**
+     * 로컬 정보를 변경한 interceptor({@link #localeChangeInterceptor} 참고)를 시스템 레지스터리에 저장한다.
+     * 로컬 정보를 변경한 interceptor는 localeChangeInterceptor 매서드를 통해 생성한다.
+     * @param registry - InterceptorRegistry타입의 Interceptor의 저징 및 엑세스를 제공한다. (Spring에서 주입해준다.)
+     */
+    @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(localeChangeInterceptor());
     }
 
+    /**
+     * resources/i18n에 있는 메세지를 가져오기 위한 설정
+     * @param basename 사용자 지정 메시지가 정의되어있는 base디렉토리 위치를 나타낸다. (i18n/exception)
+     * @param encoding 인코딩 정보 (application.yml에 UTF-8로 설정했다.)
+     * @return yml메세지를 사용하기 위해 설정한 객체를 반환
+     */
     @Bean
     public MessageSource messageSource(
             @Value("${spring.messages.basename}") String basename,
@@ -51,8 +72,21 @@ public class MessageConfiguration implements WebMvcConfigurer {
         return ymlMessageSource;
     }
 
-    // locale 정보에 따라 다른 yml 파일을 읽도록 처리
+    /**
+     * 메세지 다국화를 위한 class<br>
+     * 해당 inner class는 다음 메서드에서 사용됩니다. {@link #messageSource(String, String)}
+     * @author 정시원
+     */
     private static class YamlMessageSource extends ResourceBundleMessageSource {
+        /**
+         * 파일이나 클래스의 정보를 가져오는 객체({@link ResourceBundle})를 반환하는 매서드 <br>
+         * 우리 프로젝트에서는 yml속 message를 가져오는데 사용한다.
+         * @param basename 사용자 지정 메시지가 정의되어있는 base디렉토리 위치를 나타낸다.
+         * @param locale 지역정보
+         * @return resourceBundle - java.utils에서 제공해주는 다국어 관련 객체
+         * @throws MissingResourceException 리소스가 없을 때 발생합니다.(예시. i18n속 yml에 메세지가 없을 때)
+         * @author 정시원
+         */
         @Override
         protected ResourceBundle doGetBundle(String basename, Locale locale) throws MissingResourceException {
             return ResourceBundle.getBundle(basename, locale, YamlResourceBundle.Control.INSTANCE);

--- a/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
+++ b/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
@@ -1,4 +1,4 @@
-package com.server.EZY.config.exception;
+package com.server.EZY.config.message;
 
 import net.rakugakibox.util.YamlResourceBundle;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
+++ b/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
@@ -19,8 +19,8 @@ import java.util.ResourceBundle;
 public class MessageConfiguration implements WebMvcConfigurer {
 
     /**
-     * 기본적으로 세션을 한국으로 설정한다
-     * @return sessionLocaleResolver - 세션의 지역정보를 한국으로 설정한 객체
+     * 세션의 기본값을 한국으로 설정한다.
+     * @return sessionLocaleResolver - 세션의 지역 정보를 한국으로 설정한 객체
      * @author 정시원
      */
     @Bean
@@ -32,7 +32,7 @@ public class MessageConfiguration implements WebMvcConfigurer {
 
     /**
      * Request의 Locale 정보에 의해 Locale을 변경한 객체(LocaleChangeInterceptor)를 반환한다.
-     * @return LocaleChangeInterceptor
+     * @return LocaleChangeInterceptor Locale 정보를 변경한 Interceptor 객체
      * @author 정시원
      */
     @Bean
@@ -43,9 +43,8 @@ public class MessageConfiguration implements WebMvcConfigurer {
     }
 
     /**
-     * 로컬 정보를 변경한 interceptor({@link #localeChangeInterceptor} 참고)를 시스템 레지스터리에 저장한다.
-     * 로컬 정보를 변경한 interceptor는 localeChangeInterceptor 매서드를 통해 생성한다.
-     * @param registry - InterceptorRegistry타입의 Interceptor의 저징 및 엑세스를 제공한다. (Spring에서 주입해준다.)
+     * 로컬 정보를 변경한 interceptor({@link #localeChangeInterceptor} 참고)를 시스템 레지스터리에 저장한다.<br>
+     * @param registry Interceptor의 저장 및 엑세스를 제공한다. (Spring에서 주입한다.)
      */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -53,10 +52,10 @@ public class MessageConfiguration implements WebMvcConfigurer {
     }
 
     /**
-     * resources/i18n에 있는 메세지를 가져오기 위한 설정
-     * @param basename 사용자 지정 메시지가 정의되어있는 base디렉토리 위치를 나타낸다. (i18n/exception)
+     * resources/i18n 에 있는 메시지를 가져오기 위한 설정
+     * @param basename 사용자 지정 메시지가 정의되어있는 base 디렉토리 위치를 나타낸다. (i18n/exception)
      * @param encoding 인코딩 정보 (application.yml에 UTF-8로 설정했다.)
-     * @return yml메세지를 사용하기 위해 설정한 객체를 반환
+     * @return yml 메시지를 사용하기 위해 설정한 객체((YamlMessageSource)MessageSource)를 반환
      */
     @Bean
     public MessageSource messageSource(
@@ -73,18 +72,18 @@ public class MessageConfiguration implements WebMvcConfigurer {
     }
 
     /**
-     * 메세지 다국화를 위한 class<br>
+     * 메시지 다국화를 위한 class<br>
      * 해당 inner class는 다음 메서드에서 사용됩니다. {@link #messageSource(String, String)}
      * @author 정시원
      */
     private static class YamlMessageSource extends ResourceBundleMessageSource {
         /**
          * 파일이나 클래스의 정보를 가져오는 객체({@link ResourceBundle})를 반환하는 매서드 <br>
-         * 우리 프로젝트에서는 yml속 message를 가져오는데 사용한다.
-         * @param basename 사용자 지정 메시지가 정의되어있는 base디렉토리 위치를 나타낸다.
-         * @param locale 지역정보
-         * @return resourceBundle - java.utils에서 제공해주는 다국어 관련 객체
-         * @throws MissingResourceException 리소스가 없을 때 발생합니다.(예시. i18n속 yml에 메세지가 없을 때)
+         * 우리 프로젝트에서는 yml속 message를 가져오는 데 사용한다.
+         * @param basename 사용자 지정 메시지가 정의되어있는 base 디렉토리 위치를 나타낸다.
+         * @param locale 지역(국가)정보
+         * @return resourceBundle - java.util에서 제공해주는 다국어 관련 객체
+         * @throws MissingResourceException 리소스가 없을 때 발생합니다. (예시. i18n 속 yml에 메시지가 없을 때)
          * @author 정시원
          */
         @Override


### PR DESCRIPTION
### 한일
#### 1.  MessageConfiguration속 모든 메서드와 inner class에 대해 주석을 추가했습니다.
#### 2. `MessageConfiguration` class가 속해 있는 `config.exception`패키지를 `config.message`로 변경했습니다.
`Message`에 대한 설정을 가지고 있는 `MessageConfiguration`가 `exception` package에 있어 직관적이지 못하다고 판단하여
`config.exception` 패키지를 `config.message`로 패키지 명 변경했습니다.

### 코드리뷰 원해요
- 주석에 대한 오타, 이상한 구문 피드백
- 패키지 혹은 클레스 명에 대한 피드백

### 추가적인 제안사항
#### configration관련 클래스명 통일
configuration 관련 클래스명을 `**Config`형식으로 통일하는게 어떠한가요?

configuration 를 담당하고 있는 클래스 명이 일정하지 않습니다. 
어떤 class는 `**Config` 형식의 이름을 가진 클래스가 있고 ex(`SwaggerConfig`, `WebConfig`)
어떤 class는 `**Configuration`형식의 이름을 가진 클래스가 있습니다. ex('MessageConfiguration', `QuerydslConfiguration`)

제 의견은 직관적이며 단어 길이가 더 짧은 `**Config`형식으로 class명을 통일하면 좋을 거 같은데 어떻게 생각하시나요?
> ex. `MessageConfiguration` &rarr; `MessageConfig`