### PR TITLE
ResponseService, CommonResult 리펙토링

### DIFF
--- a/src/main/java/com/server/EZY/exception/user/MemberExceptionHandlerImpl.java
+++ b/src/main/java/com/server/EZY/exception/user/MemberExceptionHandlerImpl.java
@@ -38,7 +38,7 @@ public class MemberExceptionHandlerImpl implements MemberExceptionHandler {
         // UsernameNotFoundExceptiond에서 해당 username으로 회원을 찾지 못했을 경우 해당 username를 Exception message에 포함하는 로직
         String insertUsernameInExceptionMassage =
                 usernameNotFoundExceptionResponseObj.getMassage().replaceAll(":username", "'" + ex.getMessage() + "'");
-        usernameNotFoundExceptionResponseObj.setMassage(insertUsernameInExceptionMassage);
+        usernameNotFoundExceptionResponseObj.updateMassage(insertUsernameInExceptionMassage);
 
         return usernameNotFoundExceptionResponseObj;
     }

--- a/src/main/java/com/server/EZY/response/ResponseService.java
+++ b/src/main/java/com/server/EZY/response/ResponseService.java
@@ -26,26 +26,16 @@ public class ResponseService {
     }
 
     /**
-     * CommonResult setting method
-     * @param result Client에게 반환할 CommonResult객체
-     * @param commonResponse 요청의 성공/실패 여부 알려주는 CommonResponse
-     * @return CommonResult - 성공/실패 응답 객체 반환
-     * @author 정시원
-     */
-    private CommonResult setResponseResult(CommonResult result, CommonResponse commonResponse){
-        result.setSuccess(commonResponse == CommonResponse.SUCCESS);
-        result.setCode(commonResponse.getCode());
-        result.setMassage(commonResponse.getMassage());
-        return result;
-    }
-
-    /**
-     * 요청 데이터가 없는 성공결과 객체 반환
-     * @return CommonResult - 성공결과 객체
+     * 요청 데이터가 없는 성공 결과 객체 반환
+     * @return CommonResult - 성공 결과를 가지고 있는 CommonResult객체
      * @author 정시원
      */
     public CommonResult getSuccessResult() {
-        return setResponseResult(new CommonResult(), CommonResponse.SUCCESS);
+        return CommonResult.builder()
+                .success(true)
+                .code(CommonResponse.SUCCESS.getCode())
+                .massage(CommonResponse.SUCCESS.getMassage())
+                .build();
     }
 
     /**
@@ -59,7 +49,6 @@ public class ResponseService {
         return new SingleResult<T>(getSuccessResult(), data);
     }
 
-
     /**
      * 다중값의 데이터가 있는 결과 객체 반환
      * @param list 다중 데이터
@@ -72,26 +61,17 @@ public class ResponseService {
     }
 
     /**
-     * 실패결과 객체 반환
-     * @return CommonResult 실패결과 객체
-     * @author 정시원
-     */
-    public CommonResult getFailResult() {
-        return setResponseResult(new CommonResult(), CommonResponse.FAIL);
-    }
-
-    /**
-     * 커스텀 실패결과 객체 반환
+     * 사용자 지정 실패 결과 객체 반환
      * @param code 반환할 code
      * @param msg 반환할 message
      * @return CommonResult - 실패결과 객체
      * @author 정시원
      */
     public CommonResult getFailResult(int code, String msg) {
-        CommonResult result = new CommonResult();
-        result.setSuccess(false);
-        result.setCode(code);
-        result.setMassage(msg);
-        return result;
+        return CommonResult.builder()
+                .success(false)
+                .code(code)
+                .massage(msg)
+                .build();
     }
 }

--- a/src/main/java/com/server/EZY/response/result/CommonResult.java
+++ b/src/main/java/com/server/EZY/response/result/CommonResult.java
@@ -1,13 +1,10 @@
 package com.server.EZY.response.result;
 
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
-@NoArgsConstructor @AllArgsConstructor
-@Getter @Setter
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE) @AllArgsConstructor
 public class CommonResult {
 
     @ApiModelProperty("응답 성공여부")

--- a/src/main/java/com/server/EZY/response/result/CommonResult.java
+++ b/src/main/java/com/server/EZY/response/result/CommonResult.java
@@ -16,6 +16,10 @@ public class CommonResult {
     @ApiModelProperty("응답 메시지")
     private String massage;
 
+    public void updateMassage(String massage){
+        this.massage = massage;
+    }
+
     public CommonResult(CommonResult commonResult){
         this.success = commonResult.success;
         this.code = commonResult.code;

--- a/src/test/java/com/server/EZY/response/ResponseServiceTest.java
+++ b/src/test/java/com/server/EZY/response/ResponseServiceTest.java
@@ -48,17 +48,6 @@ class ResponseServiceTest {
         assertEquals(SUCCESS_CODE, successResult.getCode());
     }
 
-    @Test @DisplayName("getFailResult 테스트")
-    void getFailResult_테스트(){
-        // Given When
-        CommonResult successResult = responseService.getFailResult();
-
-        // Then
-        assertEquals(false, successResult.isSuccess());
-        assertEquals(FAIL_MSG, successResult.getMassage());
-        assertEquals(FAIL_CODE, successResult.getCode());
-    }
-
     @Test @DisplayName("getSingleResult 테스트")
     void getSingleResult_테스트(){
         //Given


### PR DESCRIPTION
### 한 일
#### 1. `CommonResult`객체의 불변성 강화
- `@Setter` 제거
- 기본 생성자의 접근지정자를 `private`로 설정
- `@Builder` 추가
- message 필드가 변경되야 하는 로직이 있어 `updateMessage`메서드를 생성했습니다.
  > `MemberExceptionHandlerImpl의 usernameNotFoundException`메서드

#### 2. `ResponseService` 리펙토링
`CommonResult`의 변경사항으로 인해 `CommonResult`의 `setter`를 사용하는 로직을 `builder`를 통해 객체를 생성하는 식으로 로직을 변경했습니다.

### 코드리뷰 원해요
1. 메서드명 혹은 변수명에 대한 피드백
2. 로직에 대한 피드백
