### PR TITLE
Test/fcm

### DIFF
--- a/src/main/java/com/server/EZY/notification/FcmMessage.java
+++ b/src/main/java/com/server/EZY/notification/FcmMessage.java
@@ -3,24 +3,22 @@ package com.server.EZY.notification;
 import lombok.*;
 
 public class FcmMessage {
-    @Getter
-    @NoArgsConstructor
+    @Getter @Builder
     @AllArgsConstructor
     public static class MessageResponse{
+        private String validateOnly; // 실제로 메시지를 전달하지 않고 요청을 테스트하기위한 플래그입니다.
         private String message;
     }
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
+    @Getter @Builder
     @AllArgsConstructor
     public static class FcmRequest{
-        private String subject;
-        private String content;
+        private String title;
+        private String body;
 
-        public void setRequest(String subject, String content){
-            this.subject = subject;
-            this.content = content;
+        public void setRequest(String title, String body){
+            this.title = title;
+            this.body = body;
         }
     }
 }

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -22,8 +22,8 @@ public class FirebaseMessagingService {
     public void sendToToken (FcmMessage.FcmRequest fcmMessage, String token) throws FirebaseMessagingException{
         // [START send_to_token]
         Message message = Message.builder()
-                .putData("subject", fcmMessage.getSubject())
-                .putData("content", fcmMessage.getContent())
+                .putData("title", fcmMessage.getTitle())
+                .putData("body", fcmMessage.getBody())
                 .setToken(token)
                 .build();
 
@@ -41,8 +41,8 @@ public class FirebaseMessagingService {
     public void sendMulticast(FcmMessage.FcmRequest fcmMessage, List<String> tokens) throws FirebaseMessagingException {
         // [START send_multicast]
         MulticastMessage message = MulticastMessage.builder()
-                .putData("subject", fcmMessage.getSubject())
-                .putData("content", fcmMessage.getContent())
+                .putData("subject", fcmMessage.getTitle())
+                .putData("content", fcmMessage.getBody())
                 .addAllTokens(tokens)
                 .build();
 
@@ -64,8 +64,8 @@ public class FirebaseMessagingService {
                         .putHeader("apns-priority", "10")
                         .setAps(Aps.builder()
                                 .setAlert(ApsAlert.builder()
-                                        .setTitle(fcmMessage.getSubject())
-                                        .setBody(fcmMessage.getContent())
+                                        .setTitle(fcmMessage.getTitle())
+                                        .setBody(fcmMessage.getBody())
                                         .build())
                                 .setBadge(42)
                                 .build())

--- a/src/main/java/com/server/EZY/notification/service/IosPushNotificationsService.java
+++ b/src/main/java/com/server/EZY/notification/service/IosPushNotificationsService.java
@@ -1,17 +1,24 @@
 package com.server.EZY.notification.service;
 
+import com.server.EZY.notification.config.FirebaseMessagingConfig;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
 @Service
+@RequiredArgsConstructor
 public class IosPushNotificationsService {
-    private static final String firebase_server_key = "AAAA833iS8A:APA91bH8ncfGkXkv0ks00KAwm8voLS8Q1idk5altySnNHy3BWBCAlS0PDjXVUHr2e_aD6jKSY7qW8uApeD3rJEMKsFsucfeatwSBuMfXixGgpnRHLc6fXpCAlbkx8DgnKYTuwl9c_gbd";
+
+    private final FirebaseMessagingConfig firebaseMessagingConfig;
+
     private static final String firebase_api_url = "https://fcm.googleapis.com/fcm/send";
 
     /**
@@ -21,13 +28,13 @@ public class IosPushNotificationsService {
      * @author 전지환
      */
     @Async
-    public CompletableFuture<String> send(HttpEntity<String> entity){
+    public CompletableFuture<String> send(HttpEntity<String> entity) throws IOException {
         RestTemplate restTemplate = new RestTemplate();
 
         ArrayList<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
-
-        interceptors.add(new HeaderRequestInterceptor("Authorization", "key=" + firebase_server_key));
-        interceptors.add(new HeaderRequestInterceptor("Content-Type", "application/json; UTF-8 "));
+        final String accessToken = firebaseMessagingConfig.getAccessToken();
+        interceptors.add(new HeaderRequestInterceptor(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+        interceptors.add(new HeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8"));
         restTemplate.setInterceptors(interceptors);
 
         String firebaseResponse = restTemplate.postForObject(firebase_api_url, entity, String.class);

--- a/src/test/java/com/server/EZY/notification/config/FirebaseMessagingConfigTest.java
+++ b/src/test/java/com/server/EZY/notification/config/FirebaseMessagingConfigTest.java
@@ -29,6 +29,6 @@ public class FirebaseMessagingConfigTest {
     @DisplayName("getConnection method 테스트")
     public void getConnection_fcm() throws IOException {
         HttpURLConnection connection = firebaseMessagingConfig.getConnection();
-        assertTrue(connection!=null);
+        assertNotNull(connection);
     }
 }

--- a/src/test/java/com/server/EZY/notification/service/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/server/EZY/notification/service/FirebaseMessagingServiceTest.java
@@ -20,8 +20,8 @@ public class FirebaseMessagingServiceTest {
     public void sendToToken() throws FirebaseMessagingException {
         //Given
         FcmMessage.FcmRequest sayHello = FcmMessage.FcmRequest.builder()
-                .subject("안녕하세요")
-                .content("Hello world!")
+                .title("안녕하세요")
+                .body("Hello world!")
                 .build();
 
         String token = "38862C718A0C40968254F8EB0E2E64156E35A8BAB91CE1664D9E19B530DEA8F6";


### PR DESCRIPTION
### 한 일
- `FcmMessage`에 대한 필드를 `FireBaseMessgingService`클레스의 메서드에 맞게 변경했습니다.
- `IosPushNotificationsService`의 server_token은 FirebaseMessagingConfig의 getAccessToken()으로 대체 되었습니다.
- 그 외 자잘한 리펙토링