### PR TITLE
Update 메시징 처리를 위한 FirebaseMessaging설정 후 Bean으로 등록하여 IoC가 관리하도록 함

### DIFF
--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -1,6 +1,10 @@
 package com.server.EZY.notification.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +22,28 @@ public class FirebaseMessagingConfig {
     private final String MESSAGING_SCOPE = "https://www.googleapis.com/auth/firebase.messaging";
     private final String[] SCOPES = { MESSAGING_SCOPE };
 
+    private final String firebaseConfigPath = "firebase-service-account.json";
+
+    /**
+     * FCM메시지를 보내기 위해 FirebaseMessaging객체를 설정 후 Bean으로 등록해 IoC가 관리하도록 하는 매서드
+     * @return FirebaseMessaging
+     * @throws IOException -
+     * @author 정시원
+     */
+    @Bean
+    private FirebaseMessaging firebaseMessaging() throws IOException {
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(Arrays.asList(SCOPES));
+        FirebaseOptions firebaseOptions = FirebaseOptions
+                .builder()
+                .setCredentials(googleCredentials)
+                .build();
+
+        FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, PROJECT_ID);
+        return FirebaseMessaging.getInstance(app);
+    }
+
     /**
      * 이 메서드는 google fcm 서버로 부터 Access token 을 발급 받기 위한 과정입니다.
      * @return Access token.
@@ -25,7 +51,6 @@ public class FirebaseMessagingConfig {
      * @author 전지환
      */
     public final String getAccessToken() throws IOException {
-        String firebaseConfigPath = "firebase-service-account.json";
       
         GoogleCredentials googleCredentials = GoogleCredentials
                 .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -12,6 +12,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class FirebaseMessagingService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
     /**
      * Client device-token 을 이용하여 해당 device 에 알림을 전송합니다.
      * @param fcmMessage
@@ -27,7 +30,7 @@ public class FirebaseMessagingService {
                 .setToken(token)
                 .build();
 
-        String response = FirebaseMessaging.getInstance().send(message);
+        String response = firebaseMessaging.send(message);
         log.info("Successfully sent message: {}", response);
     }
 

--- a/src/test/java/com/server/EZY/notification/service/FirebaseMessagingServiceTest.java
+++ b/src/test/java/com/server/EZY/notification/service/FirebaseMessagingServiceTest.java
@@ -2,7 +2,7 @@ package com.server.EZY.notification.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.server.EZY.notification.FcmMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### 한 일
#### `FirebaseMessaging`객체에 FCM관련 설정을 세팅 후 Bean으로 등록해 IoC에서 관리하도록 설정 했습니다.
`FirebaseMessagingServiceTest`에서 발생하던 `IllegalStateException`를 해결 했습니다.
![image](https://user-images.githubusercontent.com/62932968/133424782-8ca34bbf-dabc-497e-a28f-b1b1005e0042.png)

그 후 정확한 원인은 모르곘지만 `FirebaseMessagingException`이 발생합니다.
> 아마 디바이스 토큰이 올바르지 않아서 생기는 문제인것 같습니다. 
> @Y00ujin 님이 새로운 디바이스 토큰을 발급받아 전달받은 후 테스트 진행할 예정입니다.

해당 에러메시지 - FirebaseMessagingException
![image](https://user-images.githubusercontent.com/62932968/133425140-66fe7d45-8ad3-45d7-8e80-68d5c1059c6e.png)
