### PR TITLE
일부 테스트 코드에서 발생하던 IllegalStateException해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ dependencies {
 	implementation group: 'com.notnoop.apns', name: 'apns', version: '1.0.0.Beta6'
 
 	//*** For Firebase ***//
-	implementation 'com.google.firebase:firebase-admin:6.8.1'
+	implementation 'com.google.firebase:firebase-admin:8.0.1'
+
 
 	//*** okhttp3 ***//
 	implementation 'com.squareup.okhttp3:okhttp:4.9.1'

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -30,12 +30,12 @@ public class FirebaseMessagingConfig {
     private final String firebaseConfigPath = "firebase-service-account.json";
 
     /**
-     * FCM메시지를 보내기 위해 프로젝트의 인증정보를 담고있는 FirebaseApp객체를 Spring이 Bean을 로드하는 시점에 초기화 하는 객체.<br>
+     * FCM메시지를 보내기 위해 프로젝트의 인증정보를 담고있는 FirebaseApp객체를 Spring이 Bean을 로드하는 시점에 초기화 한다.<br>
      *
-     * {@link FirebaseApp#getInstance(String)}는 초기화 된 인스턴스가 없으면 {@link IllegalStateException}를 발생시킨다..<br>
-     * test code에서 {@link IllegalStateException}("FirebaseApp name [앱 이름] already exists!") 이 발생하여 try-catch문을 작성했다.
+     * {@link FirebaseApp#getInstance(String)}는 초기화 된 인스턴스가 없으면 {@link IllegalStateException}를 발생시킨다.<br>
+     * test code에서 {@link IllegalStateException}("FirebaseApp name [앱 이름] already exists!") 이 발생하여 try-catch문을 함
      * @return FirebaseMessaging FCM푸시 알람을 보낼 수 있는 객체
-     * @throws IOException Stream을 얻기위해 I/O작업을 하므로 발생할 수 있습니다.
+     * @throws IOException Stream을 얻기위해 I/O작업을 하므로 발생할 수 있다.
      * @author 정시원
      */
     @PostConstruct
@@ -61,7 +61,7 @@ public class FirebaseMessagingConfig {
     }
 
     /**
-     * FCM메시지를 보내기위한 {@link FirebaseMessaging}객체를 만들어 Bean으로 등록했다,
+     * FCM메시지를 보내기위한 {@link FirebaseMessaging}객체를 만들어 Bean으로 등록함
      * @return 서버에서 한 번 초기화 한 FirebaseApp 객체로 만든 메시징을 보내기 위한 {@link FirebaseMessaging}객체
      * @see #firebaseAppInit()
      * @author 정시원

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 @Slf4j
 @Configuration
 public class FirebaseMessagingConfig {
-    public static final String PROJECT_ID = "ezy-fcm";
+    private final String PROJECT_ID = "ezy-fcm";
     private final String BASE_URL = "https://fcm.googleapis.com";
     private final String FCM_SEND_ENDPOINT = "/v1/projects/" + PROJECT_ID + "/messages:send";
 

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -13,6 +13,10 @@ import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * FCM관련 구성요소를 초기화하는 Config클래스
+ * @author 정시원
+ */
 @Slf4j
 @Configuration
 public class FirebaseMessagingConfig {
@@ -49,16 +53,17 @@ public class FirebaseMessagingConfig {
                 .setProjectId(PROJECT_ID)
                 .build();
 
-        try{
-            FirebaseApp.getInstance(PROJECT_ID); // FirebaseApp에 PROJECT_ID에 대한 인스턴스가 없을 때
+        try{// FirebaseApp에 PROJECT_ID에 대한 인스턴스가 없을 때
+            FirebaseApp.getInstance(PROJECT_ID);
         }catch(IllegalStateException e){
-            FirebaseApp.initializeApp(firebaseOptions, PROJECT_ID);
+            FirebaseApp.initializeApp(firebaseOptions, PROJECT_ID); // PROJECT_ID라는 이름을 가진 FirebaseApp객체를 생성한다.
         }
     }
 
     /**
-     * FCM메시지를 보내기위한 FirebaseMessaging객체를 만들어 Bean으로 등록했다,
-     * @return 서버에서 한 번 초기화 한 FirebaseApp 객체로 만든 메시징을 보내기 위한 FirebaseMessaging객체
+     * FCM메시지를 보내기위한 {@link FirebaseMessaging}객체를 만들어 Bean으로 등록했다,
+     * @return 서버에서 한 번 초기화 한 FirebaseApp 객체로 만든 메시징을 보내기 위한 {@link FirebaseMessaging}객체
+     * @see #firebaseAppInit()
      * @author 정시원
      */
     @Bean

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -28,8 +28,8 @@ public class FirebaseMessagingConfig {
     /**
      * FCM메시지를 보내기 위해 프로젝트의 인증정보를 담고있는 FirebaseApp객체를 Spring이 Bean을 로드하는 시점에 초기화 하는 객체.<br>
      *
-     * {@link FirebaseApp#getInstance(String)}는 초기화 된 인스턴스가 없으면 {@link IllegalStateException}를 발생시킵니다.<br>
-     * test code에서 {@link IllegalStateException}("FirebaseApp name [앱 이름] already exists!") 이 발생하여 try-catch문을 작성했습니다.
+     * {@link FirebaseApp#getInstance(String)}는 초기화 된 인스턴스가 없으면 {@link IllegalStateException}를 발생시킨다..<br>
+     * test code에서 {@link IllegalStateException}("FirebaseApp name [앱 이름] already exists!") 이 발생하여 try-catch문을 작성했다.
      * @return FirebaseMessaging FCM푸시 알람을 보낼 수 있는 객체
      * @throws IOException Stream을 얻기위해 I/O작업을 하므로 발생할 수 있습니다.
      * @author 정시원
@@ -55,4 +55,15 @@ public class FirebaseMessagingConfig {
             FirebaseApp.initializeApp(firebaseOptions, PROJECT_ID);
         }
     }
+
+    /**
+     * FCM메시지를 보내기위한 FirebaseMessaging객체를 만들어 Bean으로 등록했다,
+     * @return 서버에서 한 번 초기화 한 FirebaseApp 객체로 만든 메시징을 보내기 위한 FirebaseMessaging객체
+     * @author 정시원
+     */
+    @Bean
+    public FirebaseMessaging firebaseMessaging(){
+        return FirebaseMessaging.getInstance(FirebaseApp.getInstance(PROJECT_ID));
+    }
+
 }

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -1,9 +1,7 @@
 package com.server.EZY.notification.service;
 
-import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.*;
 import com.server.EZY.notification.FcmMessage;
-import com.server.EZY.notification.config.FirebaseMessagingConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -1,7 +1,9 @@
 package com.server.EZY.notification.service;
 
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.*;
 import com.server.EZY.notification.FcmMessage;
+import com.server.EZY.notification.config.FirebaseMessagingConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,9 +29,10 @@ public class FirebaseMessagingService {
         // FirebaseMessging으로 푸시알람을 보내기 위한 객체
         Message message = Message.builder()
                 .setNotification(
-                        new Notification(
-                                fcmMessage.getTitle(),
-                                fcmMessage.getBody())
+                        Notification.builder()
+                                .setTitle(fcmMessage.getTitle())
+                                .setBody(fcmMessage.getBody())
+                                .build()
                 )
 //                .putData("title", fcmMessage.getTitle()) // putData는 추가적인 데이터를 보내고 싶을 때 사용한다.
 //                .putData("body", fcmMessage.getBody())
@@ -52,9 +55,10 @@ public class FirebaseMessagingService {
         // [START send_multicast]
         MulticastMessage message = MulticastMessage.builder()
                 .setNotification(
-                        new Notification(
-                                fcmMessage.getTitle(),
-                                fcmMessage.getBody())
+                        Notification.builder()
+                                .setTitle(fcmMessage.getTitle())
+                                .setBody(fcmMessage.getBody())
+                                .build()
                 )
                 .addAllTokens(tokens)
                 .build();


### PR DESCRIPTION
### 한 일
- firebase-admin 의존성 버전을 업그레이드 했습니다. (6.8.1 &rarr; 8.0.1)
  > 버전 업그레이드 중 `FirebaseMessagingService`에서 `Notification`객체를 생성하는 방법이 builder패턴으로 변경되어 수정했습니다.
- `FirebaseApp`객체를 무조건 한 번만 초기화 하도록`FirebaseMessagingConfig`클래스 속 메서드를 변경하여 테스트 코드가 실패하는 현상을 고쳤습니다.

### 문제 원인
`FirebaseApp`는 팩토리 패턴을 이용해 `FirebaseApp`를 생성합니다. 
문제의 정확한 원인은 모르겠지만 원인은 `FirebaseMessagingConfig`에 `@Bean`으로 등록된 `firebaseMessaging()`메서드가 두번 호출되어 `FirebaseApp`에서 똑같은 이름을 가진 App이 두 번 초기화(`FirebaseApp.initializeApp(firebaseOptions))` 되려고 했습니다.
 
이렇게 똑같은 이름을 가진 `FirebaseApp`객체가 두번 이상 초기화 되면 `IllegalStateException`가 발생합니다.
이로 인해 테스트 코드에서 `IllegalStateException`가 발생해 테스트가 실패했습니다.

### 코드리뷰 원해요
- 주석에 잘못된 내용 있을 시 피드백
- 로직에 대한 피드백
- 명명에 대한 피드백