### PR TITLE
회원가입/로그인 fcm token 관련 로직 추가

### DIFF
--- a/src/main/java/com/server/EZY/model/member/MemberEntity.java
+++ b/src/main/java/com/server/EZY/model/member/MemberEntity.java
@@ -36,6 +36,9 @@ public class MemberEntity extends BaseTimeEntity implements UserDetails{
     @Column(name = "phone_number", nullable = false, unique = true)
     private String phoneNumber;
 
+    @Column(name = "fcm_token", nullable = true, unique = true)
+    private String fcmToken;
+
     @Enumerated(STRING) @Column(name = "role")
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "role", joinColumns = @JoinColumn(name = "user_id"))

--- a/src/main/java/com/server/EZY/model/member/MemberEntity.java
+++ b/src/main/java/com/server/EZY/model/member/MemberEntity.java
@@ -99,6 +99,10 @@ public class MemberEntity extends BaseTimeEntity implements UserDetails{
         this.phoneNumber = phoneNumber != null ? phoneNumber : this.phoneNumber;
     }
 
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken != null ? fcmToken : this.fcmToken;
+    }
+
     @Override @Generated
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
@@ -2,6 +2,7 @@ package com.server.EZY.model.member.dto;
 
 import com.server.EZY.model.member.enum_type.Role;
 import com.server.EZY.model.member.MemberEntity;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -23,9 +24,12 @@ public class AuthDto {
     @Size(min = 4, max = 10)
     private String password;
 
-    public AuthDto(String username, String password) {
+    private String fcmToken;
+
+    public AuthDto(String username, String password, String fcmToken) {
         this.username = username;
         this.password = password;
+        this.fcmToken = fcmToken;
     }
 
     public MemberEntity toEntity(){

--- a/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
@@ -26,10 +26,13 @@ public class MemberDto {
     @Size(min = 11, max = 11)
     private String phoneNumber;
 
-    public MemberDto(String username, String password, String phoneNumber) {
+    private String fcmToken;
+
+    public MemberDto(String username, String password, String phoneNumber, String fcmToken) {
         this.username = username;
         this.password = password;
         this.phoneNumber = phoneNumber;
+        this.fcmToken = fcmToken;
     }
 
     public MemberEntity toEntity(){
@@ -37,6 +40,7 @@ public class MemberDto {
                 .username(this.getUsername())
                 .password(this.getPassword())
                 .phoneNumber(this.getPhoneNumber())
+                .fcmToken(this.getFcmToken())
                 .roles(Collections.singletonList(Role.ROLE_CLIENT))
                 .build();
     }

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -71,6 +71,7 @@ public class MemberServiceImpl implements MemberService {
      * @author 배태현
      */
     @Override
+    @Transactional
     public Map<String, String> signin(AuthDto loginDto) {
         MemberEntity memberEntity = memberRepository.findByUsername(loginDto.getUsername());
         if (memberEntity == null) throw new MemberNotFoundException();
@@ -83,6 +84,8 @@ public class MemberServiceImpl implements MemberService {
 
         redisUtil.deleteData(memberEntity.getUsername()); // accessToken이 만료되지않아도 로그인 할 때 refreshToken도 초기화해서 다시 생성 후 redis에 저장한다.
         redisUtil.setDataExpire(memberEntity.getUsername(), refreshToken, REDIS_EXPIRATION_TIME);
+
+        memberEntity.updateFcmToken(loginDto.getFcmToken());
 
         Map<String ,String> map = new HashMap<>();
         map.put("username", loginDto.getUsername());


### PR DESCRIPTION
### 제가 한 일이에요
* Member Entity `fcm token` **column 추가** (null 가능)
* 회원가입 때 `fcm token` 다른 정보들과 같이 **저장** (null 가능)
* 로그인 때에 `fcm token` 넘겨주어 변경감지 **update**로직 추가(null 가능)
> fcm token에 대한 제약조건은 따로 없는 것 같아서 제약조건 없이 그냥 놔 두었습니다. 
(영문, 숫자, 특수문자 등 다 섞여있고 길이도 일정하지 않아요 !)

### fcm token 저장, update 결과
* **일반적**인 fcm token 저장 결과
![스크린샷 2021-09-30 오전 8 49 43](https://user-images.githubusercontent.com/69895394/135364520-34d24495-8199-404c-a9e7-03c9bfc1d8e2.png)

* fcm token이 **null일 경우** 결과 (실제 서비스 상에선 알림허용을 하지 않았을 때)
![스크린샷 2021-09-30 오전 8 52 32](https://user-images.githubusercontent.com/69895394/135364525-c90d176d-2986-4dc2-b6bf-e661c7449483.png)

* fcm token이 **update되었을 때** 쿼리문 (디바이스 변경을 감지(fcm token 변경감지)하고 fcm token을 update)
<img width="1917" alt="스크린샷 2021-09-30 오전 8 50 36" src="https://user-images.githubusercontent.com/69895394/135364527-10a4894b-8e16-4cdc-aa11-9bd2c711549a.png">