### PR TITLE
Rename ResponseStatus -> ErrandResponseStatus

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandStatusEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandStatusEntity.java
@@ -1,6 +1,6 @@
 package com.server.EZY.model.plan.errand;
 
-import com.server.EZY.model.plan.errand.enum_type.ResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,19 +28,19 @@ public class ErrandStatusEntity {
 
     @Column(name = "response_status")
     @Enumerated(EnumType.STRING)
-    private ResponseStatus responseStatus;
+    private ErrandResponseStatus errandResponseStatus;
 
     /**
      * 심부름의 상태를 추가하는 생성자
      * @param senderIdx 발신자의 MemberIdx
      * @param recipientIdx 수신자의 MemberIdx
-     * @param responseStatus 심부름의 상태
+     * @param errandResponseStatus 심부름의 상태
      * @author 정시원
      */
     @Builder
-    public ErrandStatusEntity(Long senderIdx, Long recipientIdx, ResponseStatus responseStatus){
+    public ErrandStatusEntity(Long senderIdx, Long recipientIdx, ErrandResponseStatus errandResponseStatus){
         this.senderIdx = senderIdx;
         this.recipientIdx = recipientIdx;
-        this.responseStatus = responseStatus;
+        this.errandResponseStatus = errandResponseStatus;
     }
 }

--- a/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
@@ -1,0 +1,5 @@
+package com.server.EZY.model.plan.errand.enum_type;
+
+public enum ErrandResponseStatus {
+    CANCEL, ACCEPT, READ, NOT_READ
+}

--- a/src/main/java/com/server/EZY/model/plan/errand/enum_type/ResponseStatus.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/enum_type/ResponseStatus.java
@@ -1,5 +1,0 @@
-package com.server.EZY.model.plan.errand.enum_type;
-
-public enum ResponseStatus {
-    CANCEL, ACCEPT, NOT_READ, READ
-}

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -5,7 +5,7 @@ import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import com.server.EZY.model.plan.errand.ErrandStatusEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
-import com.server.EZY.model.plan.errand.enum_type.ResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import com.server.EZY.model.plan.errand.repository.ErrandRepository;
 import com.server.EZY.util.CurrentUserUtil;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +36,7 @@ public class ErrandServiceImpl implements ErrandService{
         ErrandStatusEntity errandStatusEntity = ErrandStatusEntity.builder()
                 .senderIdx(currentUser.getMemberIdx())
                 .recipientIdx(recipientIdx)
-                .responseStatus(ResponseStatus.NOT_READ)
+                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
                 .build();
 
         return errandRepository.save(errandSetDto.saveToEntity(currentUser, errandStatusEntity));

--- a/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
@@ -5,7 +5,7 @@ import com.server.EZY.model.member.enum_type.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
-import com.server.EZY.model.plan.errand.enum_type.ResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import com.server.EZY.model.plan.errand.repository.ErrandRepository;
 import com.server.EZY.model.plan.errand.repository.ErrandStatusRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;
@@ -62,7 +62,7 @@ class ErrandTest {
          * errandStatus를 만들어 시원과 지환의 각각생성된 Errand테이블과 연관관계를 맻고 저장한다.
          */
         ErrandStatusEntity errandStatusEntity = ErrandStatusEntity.builder()
-                .responseStatus(ResponseStatus.NOT_READ)
+                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
                 .senderIdx(memberSiwon.getMemberIdx())
                 .recipientIdx(memberJihwan.getMemberIdx())
                 .build();
@@ -116,7 +116,7 @@ class ErrandTest {
     void 심부름_삭제_테스트(){
         // Then
         ErrandStatusEntity errandStatusEntity = ErrandStatusEntity.builder()
-                .responseStatus(ResponseStatus.NOT_READ)
+                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
                 .senderIdx(memberSiwon.getMemberIdx())
                 .recipientIdx(memberJihwan.getMemberIdx())
                 .build();

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
@@ -8,7 +8,7 @@ import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
-import com.server.EZY.model.plan.errand.enum_type.ResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import com.server.EZY.util.CurrentUserUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -92,7 +92,7 @@ class ErrandServiceImplTest {
         ErrandEntity errandEntity = errandService.sendErrand(errandSetDto);
 
         //Then
-        assertEquals(ResponseStatus.NOT_READ, errandEntity.getErrandStatusEntity().getResponseStatus());
+        assertEquals(ErrandResponseStatus.NOT_READ, errandEntity.getErrandStatusEntity().getErrandResponseStatus());
         assertEquals(memberRepository.findByUsername("@kim").getMemberIdx(), errandEntity.getErrandStatusEntity().getRecipientIdx());
     }
 


### PR DESCRIPTION
### 한 일
#### enum class인 `ResponseStatus`를 `ErrandResponseStatus`로 이름을 변경했습니다.
이로 인해 기존 `ResponseStatus`를 사용하던 class들이 변경되었습니다.

### 코드 리뷰 원해요
- 해당 rename에 대한 명명 피드백