### PR TITLE
Add delete-merged-branch-bot config

### DIFF
--- a/.github/delete-merged-branch-config.yml
+++ b/.github/delete-merged-branch-config.yml
@@ -1,0 +1,4 @@
+exclude:
+  - develop
+
+delete_closed_pr: true


### PR DESCRIPTION
#### 한 일
develop -> master 하는 과정에서 config 가 되지 않아 develop이 삭제되는 결과를 초래함.
#### 개선 방안
`.github/delete-merged-branch-config.yml` 를 만들어 `develop` 브랜치만 삭제 목록에서 제외했음.