### PR TITLE
Hotfix exclude properties

### DIFF
--- a/.github/delete-merged-branch-config.yml
+++ b/.github/delete-merged-branch-config.yml
@@ -1,4 +1,5 @@
 exclude:
-  - develop
+  - feature/*
+  - master
 
 delete_closed_pr: true


### PR DESCRIPTION
#### 한 일
1. exclude 프로퍼티에 해당하는 브랜치는 해당 브랜치 기준으로 PR 이 들어왔을 때를 의미한다.

#### 개선 방안
master에 들어오는 PR, feature에 들어오는 PR의 branch는 삭제하지 않음.