### PR TITLE
fcmToken 변경 로직 로그인 로직과 분리

### DIFF
--- a/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
@@ -101,6 +101,12 @@ public class CertifiedMemberController {
         return responseService.getSuccessResult();
     }
 
+    /**
+     * fcmToken 변경 컨트롤러
+     * @param fcmTokenDto
+     * @return SuccessResult
+     * @author 배태현
+     */
     @PostMapping("/fcmtoken")
     @ApiOperation(value = "fcmToken 변경", notes = "fcmToken 변경")
     @ResponseStatus( HttpStatus.OK )

--- a/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
@@ -1,6 +1,7 @@
 package com.server.EZY.model.member.controller;
 
 import com.server.EZY.model.member.dto.AuthDto;
+import com.server.EZY.model.member.dto.FcmTokenDto;
 import com.server.EZY.model.member.dto.PhoneNumberChangeDto;
 import com.server.EZY.model.member.dto.UsernameChangeDto;
 import com.server.EZY.model.member.service.MemberService;
@@ -97,6 +98,18 @@ public class CertifiedMemberController {
     })
     public CommonResult deleteUser(@Valid @RequestBody AuthDto deleteUserDto) {
         memberService.deleteUser(deleteUserDto);
+        return responseService.getSuccessResult();
+    }
+
+    @PostMapping("/fcmtoken")
+    @ApiOperation(value = "fcmToken 변경", notes = "fcmToken 변경")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult updateFcmToken(@RequestBody FcmTokenDto fcmTokenDto) {
+        memberService.updateFcmToken(fcmTokenDto);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
@@ -21,7 +21,7 @@ public class AuthDto {
     private String username;
 
     @NotBlank
-    @Size(min = 4, max = 10)
+    @Size(min = 8)
     private String password;
 
     public AuthDto(String username, String password) {

--- a/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/AuthDto.java
@@ -24,12 +24,9 @@ public class AuthDto {
     @Size(min = 4, max = 10)
     private String password;
 
-    private String fcmToken;
-
-    public AuthDto(String username, String password, String fcmToken) {
+    public AuthDto(String username, String password) {
         this.username = username;
         this.password = password;
-        this.fcmToken = fcmToken;
     }
 
     public MemberEntity toEntity(){

--- a/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
@@ -1,0 +1,2 @@
+package com.server.EZY.model.member.dto;public class FcmTokenDto {
+}

--- a/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
@@ -2,8 +2,8 @@ package com.server.EZY.model.member.dto;
 
 import lombok.*;
 
-@Getter @Setter @Builder
-@AllArgsConstructor @NoArgsConstructor
+@Getter @Builder
+@AllArgsConstructor @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmTokenDto {
 
     private String fcmToken;

--- a/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
@@ -1,9 +1,9 @@
 package com.server.EZY.model.member.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-@Getter @Setter
+@Getter @Setter @Builder
+@AllArgsConstructor @NoArgsConstructor
 public class FcmTokenDto {
 
     private String fcmToken;

--- a/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/FcmTokenDto.java
@@ -1,2 +1,10 @@
-package com.server.EZY.model.member.dto;public class FcmTokenDto {
+package com.server.EZY.model.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class FcmTokenDto {
+
+    private String fcmToken;
 }

--- a/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/MemberDto.java
@@ -18,7 +18,7 @@ public class MemberDto {
     private String username;
 
     @NotBlank
-    @Size(min = 4, max = 10)
+    @Size(min = 8)
     private String password;
 
     @NotBlank

--- a/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PasswordChangeDto.java
@@ -16,6 +16,6 @@ public class PasswordChangeDto {
     private String username;
 
     @NotBlank
-    @Size(min = 4, max = 10)
+    @Size(min = 8)
     private String newPassword;
 }

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -29,4 +29,5 @@ public interface MemberService {
 
     void deleteUser(AuthDto deleteUserDto);
 
+    void updateFcmToken(FcmTokenDto fcmTokenDto);
 }

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.dto.*;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.security.jwt.JwtTokenProvider;
+import com.server.EZY.util.CurrentUserUtil;
 import com.server.EZY.util.KeyUtil;
 import com.server.EZY.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,7 @@ public class MemberServiceImpl implements MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
     private final KeyUtil keyUtil;
+    private final CurrentUserUtil currentUserUtil;
 
     @Value("${sms.api.apikey}")
     private String apiKey;
@@ -226,5 +228,13 @@ public class MemberServiceImpl implements MemberService {
         if (passwordEncoder.matches(deleteUserDto.getPassword(), memberEntity.getPassword())) {
             memberRepository.deleteById(memberEntity.getMemberIdx());
         } else throw new MemberNotFoundException();
+    }
+
+    @Override
+    @Transactional
+    public void updateFcmToken(FcmTokenDto fcmTokenDto) {
+        MemberEntity currentUser = currentUserUtil.getCurrentUser();
+
+        currentUser.updateFcmToken(fcmTokenDto.getFcmToken());
     }
 }

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -230,6 +230,11 @@ public class MemberServiceImpl implements MemberService {
         } else throw new MemberNotFoundException();
     }
 
+    /**
+     * fcmToken 변경 서비스로직
+     * @param fcmTokenDto
+     * @author 배태현
+     */
     @Override
     @Transactional
     public void updateFcmToken(FcmTokenDto fcmTokenDto) {

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -85,8 +85,6 @@ public class MemberServiceImpl implements MemberService {
         redisUtil.deleteData(memberEntity.getUsername()); // accessToken이 만료되지않아도 로그인 할 때 refreshToken도 초기화해서 다시 생성 후 redis에 저장한다.
         redisUtil.setDataExpire(memberEntity.getUsername(), refreshToken, REDIS_EXPIRATION_TIME);
 
-        memberEntity.updateFcmToken(loginDto.getFcmToken());
-
         Map<String ,String> map = new HashMap<>();
         map.put("username", loginDto.getUsername());
         map.put("accessToken", "Bearer " + accessToken); // accessToken 반환

--- a/src/main/java/com/server/EZY/security/SecurityConfig.java
+++ b/src/main/java/com/server/EZY/security/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v1/member/refreshtoken").authenticated()// 로그인 된 유저는 모두 접근을 허용함
                 .antMatchers("/v1/member/logout").authenticated() // 로그인 된 유저는 모두 접근을 허용함
                 .antMatchers("/v1/member/delete").authenticated() // 로그인 된 유저는 모두 접근을 허용함
+                .antMatchers("/v1/member/fcmtoken").authenticated()
                 /* 이렇게 권한에 따라 url접속을 제한할 수 있다. (테스트 완료)
                 .antMatchers("/v1/member/test").hasRole("CLIENT")
                 .antMatchers("/v1/admin/test").hasRole("ADMIN")

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -392,7 +392,8 @@ public class MemberServiceTest {
         memberService.updateFcmToken(fcmTokenDto);
 
         //then
-        assertEquals(fcmTokenDto.getFcmToken(), memberRepository.findById(memberEntity.getMemberIdx()).get().getFcmToken());
+        String currentUserFcmToken = memberRepository.findById(memberEntity.getMemberIdx()).get().getFcmToken();
+        assertEquals(fcmTokenDto.getFcmToken(), currentUserFcmToken);
     }
 
     /**

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -378,6 +378,23 @@ public class MemberServiceTest {
         );
     }
 
+    @Test
+    @DisplayName("fcmToken이 잘 변경 되나요 ?")
+    public void fcmTokenUpdateTest() {
+        //given
+        FcmTokenDto fcmTokenDto = FcmTokenDto.builder()
+                .fcmToken("fAp6e7Snyk_kg9ZxvTkt-a:APA91bEsOTGuuATRSKcHnwjqLL_aiT42BoLCuVJHrsW_JmvmfLqw8Ub2bZmUycR6qDyMbU2I41UScu9-kiv5bnI70wNRBXA1ku-IiEp5LiH_ZzGNBai7ZQqY5VGsb3s-BLu13iXEiISm")
+                .build();
+
+        MemberEntity memberEntity = currentUser();
+
+        //when
+        memberService.updateFcmToken(fcmTokenDto);
+
+        //then
+        assertEquals(fcmTokenDto.getFcmToken(), memberRepository.findById(memberEntity.getMemberIdx()).get().getFcmToken());
+    }
+
     /**
      * 로그인이 되어있는 유저를 만들기위해 뺀 메서드
      * @return loginUser(현재 로그인되어있는 유저)


### PR DESCRIPTION
### 제가 한 일이에요 !
* 로그인 로직에서 fcmToken변경 로직 삭제 후 분리하여 API 따로 생성
* fcmToken 변경 서비스로직 테스트코드 작성

제가 생각한 플로우는 ...
> 앱에 로그인 
-> client에서 회원가입 때 저장되었던 fcmToken과 현재 fcmToken이 다른걸 확인 
-> 서버에 fcmToken 변경 요청을 보냅니다.

위와 같은 플로우로 로직을 작성하였습니다 !

플로우에 문제가 있어보이거나 
현재 작성한 코드보다 더 나은 방법으로 작성할 수 있는지 리뷰 받고싶습니다.