### PR TITLE
about member

### DIFF
--- a/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
@@ -29,9 +29,6 @@ public class CertifiedMemberController {
     private final MemberService memberService;
     private final ResponseService responseService;
 
-    //이 Controller가 return이 아무값도 return되지않음 공백이 뜸 (POSTMAN에서 확인)
-
-
     /**
      * 전화번호 변경 controller
      * @param phoneNumberChangeDto (username, newPhoneNumber)
@@ -93,7 +90,7 @@ public class CertifiedMemberController {
      */
     @PostMapping ("/delete")
     @ApiOperation(value = "회원탈퇴", notes = "회원탈퇴")
-    @ResponseStatus( HttpStatus.NO_CONTENT )
+    @ResponseStatus( HttpStatus.OK )
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")

--- a/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/CertifiedMemberController.java
@@ -18,6 +18,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+/**
+ * 인증/인가 후 사용할 수 있는 컨트롤러
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/v1/member")
@@ -30,10 +33,9 @@ public class CertifiedMemberController {
 
 
     /**
-     * (로그인 되어있는 상태에서) 전화번호 인증을 완료하고 전화번호를 변경할 수 있음
-     * 전화번호를 변경하는 controller
-     * @param phoneNumberChangeDto
-     * @return SuccessResult
+     * 전화번호 변경 controller
+     * @param phoneNumberChangeDto (username, newPhoneNumber)
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PutMapping("/change/phone")
@@ -50,8 +52,8 @@ public class CertifiedMemberController {
 
     /**
      * username 변경 controller
-     * @param usernameChangeDto username, newUsername
-     * @return SuccessResult
+     * @param usernameChangeDto (username, newUsername)
+     * @return CommonResult - SuccessResult
      */
     @PutMapping("/change/username")
     @ApiOperation(value = "이름 변경", notes = "이름 변경")
@@ -66,9 +68,9 @@ public class CertifiedMemberController {
     }
 
     /**
-     * "/v1/member/logout"로 요청이 들어오고 (로그인이 되어있는 상태)를 확인했기 때문에 logout한다...
+     * 로그아웃 controller
      * @param request HttpServletRequest
-     * @return SuccessResult
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @DeleteMapping("/logout")
@@ -84,9 +86,9 @@ public class CertifiedMemberController {
     }
 
     /**
-     * "/v1/member/delete"로 요청이 들어와 로그인이 되어있는상태를 확인했기 때문에 회원탈퇴 진행
-     * @param deleteUserDto
-     * @return SuccessResult
+     * 회원탈퇴 controller
+     * @param deleteUserDto (username, password)
+     * @return CommonResult -  SuccessResult
      * @author 배태현
      */
     @PostMapping ("/delete")
@@ -102,9 +104,9 @@ public class CertifiedMemberController {
     }
 
     /**
-     * fcmToken 변경 컨트롤러
-     * @param fcmTokenDto
-     * @return SuccessResult
+     * fcmToken 변경 controller
+     * @param fcmTokenDto (fcmToken)
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PostMapping("/fcmtoken")

--- a/src/main/java/com/server/EZY/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/MemberController.java
@@ -15,6 +15,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.Map;
 
+/**
+ * 인증/인가 전 사용하는 컨트롤러
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/v1/member")
@@ -25,38 +28,36 @@ public class MemberController {
 
     /**
      * 회원가입 controller
-     * @param memberDto userDto
-     * @return SuccessResult
-     * @throws Exception Exception
+     * @param memberDto userDto(username, password, phoneNumber, fcmToken)
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PostMapping("/signup")
     @ApiOperation(value = "회원가입", notes = "회원가입")
     @ResponseStatus( HttpStatus.CREATED )
-    public CommonResult signup(@Valid @RequestBody MemberDto memberDto) throws Exception {
+    public CommonResult signup(@Valid @RequestBody MemberDto memberDto) {
         memberService.signup(memberDto);
         return responseService.getSuccessResult();
     }
 
     /**
      * 로그인 controller
-     * @param loginDto loginDto
-     * @return username ,accessToken, refreshToken
-     * @throws Exception Exception
+     * @param loginDto loginDto(username, password)
+     * @return SingleResult (username ,accessToken, refreshToken)
      * @author 배태현
      */
     @PostMapping("/signin")
     @ApiOperation(value = "로그인", notes = "로그인")
     @ResponseStatus( HttpStatus.OK )
-    public SingleResult<Map<String, String>> signin(@Valid @RequestBody AuthDto loginDto) throws Exception {
+    public SingleResult<Map<String, String>> signin(@Valid @RequestBody AuthDto loginDto) {
         Map<String, String> signinData = memberService.signin(loginDto);
         return responseService.getSingleResult(signinData);
     }
 
     /**
-     * 전화번호로 인증번호 보내기
+     * 전화번호로 인증번호를 전송하는 controller
      * @param phoneNumber
-     * @return SuccessResult
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PostMapping("/auth")
@@ -68,9 +69,9 @@ public class MemberController {
     }
 
     /**
-     * 받은 인증번호가 맞는지 인증하기
+     * 받은 인증번호가 맞는지 인증하는 controller
      * @param key
-     * @return SuccessResult
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PostMapping("/auth/check")
@@ -82,27 +83,13 @@ public class MemberController {
     }
 
     /**
-     * username을 찾는 controller
-     * @param phoneNumber
-     * @return SingleResult(찾은 회원이름)
-     */
-    @PostMapping("/find/username")
-    @ApiOperation(value = "이름(아이디)찾기", notes = "이름(아이디)찾기")
-    @ResponseStatus( HttpStatus.OK )
-    public CommonResult findUsername(String phoneNumber) {
-        String username = memberService.findUsername(phoneNumber);
-        return responseService.getSingleResult(username);
-    }
-
-    /**
-     * 인증번호 인증을 한 뒤 <br>
-     * 비밀번호를 변경하게하는 controller <br>
-     * @param passwordChangeDto passwordChangeDto
-     * @return SuccessResult
+     * 비밀번호를 재설정 controller
+     * @param passwordChangeDto passwordChangeDto(username, newPassword)
+     * @return CommonResult - SuccessResult
      * @author 배태현
      */
     @PutMapping ("/change/password")
-    @ApiOperation(value = "비밀번호 찾기", notes = "비밀번호 찾기")
+    @ApiOperation(value = "비밀번호 재설정", notes = "비밀번호 재설정")
     @ResponseStatus( HttpStatus.OK )
     public CommonResult passwordChange(@Valid @RequestBody PasswordChangeDto passwordChangeDto) {
         memberService.changePassword(passwordChangeDto);

--- a/src/main/java/com/server/EZY/model/member/dto/PhoneNumberChangeDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PhoneNumberChangeDto.java
@@ -11,11 +11,6 @@ import javax.validation.constraints.Size;
 public class PhoneNumberChangeDto {
 
     @NotBlank
-    @Pattern(regexp = "^@[a-zA-Z]*$")
-    @Size(min = 1, max = 10)
-    private String username;
-
-    @NotBlank
     @Pattern(regexp = "^[0-9]{11}$")
     @Size(min = 11, max = 11)
     private String newPhoneNumber;

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -19,8 +19,6 @@ public interface MemberService {
 
     String validAuthKey(String key);
 
-    String findUsername(String phoneNumber);
-
     void changeUsername(UsernameChangeDto usernameChangeDto);
 
     void changePassword(PasswordChangeDto passwordChangeDto);

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -47,10 +47,10 @@ public class MemberServiceImpl implements MemberService {
     private long REDIS_EXPIRATION_TIME = JwtTokenProvider.REFRESH_TOKEN_VALIDATION_TIME; //6개월
 
     /**
-     * 회원가입을 하는 서비스 로직 입니다.
-     * @param memberDto
-     * @return - save가 완료되면 memberEntity를 반환합니다.
-     * @exception - else, 이미 존재하면 MemberAlreadyExistException
+     * 회원가입 서비스 로직
+     * @param memberDto memberDto(username, password, phoneNumber, fcmToken)
+     * @return - save가 완료되면 test코드를 위한 memberEntity를 반환합니다.
+     * @exception - else, 이미 존재하는 정보의 회원이라면 MemberAlreadyExistException
      * @author 배태현
      */
     @Override
@@ -65,11 +65,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그인을 하는 서비스 로직 입니다.
-     * @param loginDto
-     * @exception 1. username을 통해 회원을 찾을 수 있나요? || loginDto.getPassword()와 찾은 member의 password가 일치한가요?
-     * -> 하나라도 충족되지 않으면 MemberNotFoundException
-     * @return Map<String ,String> (username, accessToken, refreshToken)을 반환 합니다.
+     * 로그인 서비스 로직
+     * @param loginDto loginDto(username, password)
+     * @exception - username으로 member를 찾을 수 없거나, 올바르지 않은 비밀번호라면 MemberNotFoundException
+     * @return Map<String ,String> (username, accessToken, refreshToken) 반환
      * @author 배태현
      */
     @Override
@@ -96,10 +95,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그아웃하는 서비스 로직
+     * 로그아웃 서비스 로직
      * (redis에 있는 refreshToken을 지워준다) (Client는 accessToken을 지워준다)
      * @param nickname
-     * @return void
      * @author 배태현
      */
     @Override
@@ -108,10 +106,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 전화번호로 인증번호를 보내는 로직
+     * 전화번호로 인증번호를 보내는 서비스 로직
      * @param phoneNumber
-     * @exception 1. phoneNumber로 찾은 User가 null이라면 UserNotFoundException()
-     * @return 문자로 인증번호 전송
+     * @exception - phoneNumber로 member를 찾을 수 없다면 UserNotFoundException
      * @author 배태현
      */
     @Override
@@ -139,9 +136,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 문자로 받은 인증번호로 인증하는 로직
+     * 사용자가 문자로 받은 인증번호를 검증하는 서비스 로직
      * @param key
-     * @return key
+     * @return test코드 작성을 위한 key 반환
      * @author 배태현
      */
     @Override
@@ -155,24 +152,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 전화번호를 전송해 그 전화번호로
-     * 회원을 찾고 회원의 이름을 알려주는 로직
-     * @param phoneNumber
-     * @return memberEntity.getUsername()
-     * @author 배태현
-     */
-    @Override
-    public String findUsername(String phoneNumber) {
-        MemberEntity memberEntity = memberRepository.findByPhoneNumber(phoneNumber);
-        if (memberEntity == null) throw new MemberNotFoundException();
-
-        return memberEntity.getUsername();
-    }
-
-    /**
      * username을 변경하는 서비스 로직
-     * @param usernameChangeDto username, newUsername
-     * @return void
+     * @param usernameChangeDto usernameChangeDto(username, newUsername)
      * @author 배태현
      */
     @Override
@@ -186,8 +167,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 비밀번호를 변경하는 서비스 로직
-     * @param passwordChangeDto username, newPassword
-     * @return void
+     * @param passwordChangeDto passwordChangeDto(username, newPassword)
      * @author 배태현
      */
     @Override
@@ -201,8 +181,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 전화번호를 변경하는 서비스 로직
-     * @param phoneNumberChangeDto username, newPhoneNumber
-     * @return void
+     * @param phoneNumberChangeDto phoneNumberChangeDto(username, newPhoneNumber)
      * @author 배태현
      */
     @Override
@@ -216,8 +195,8 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원탈퇴 서비스 로직
-     * @param deleteUserDto
-     * @return void
+     * @param deleteUserDto deleteUserDto(username, password)
+     * @exception - 올바르지 않는 비밀번호일 시 MemberNotFoundException
      * @author 배태현
      */
     @Override
@@ -232,7 +211,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * fcmToken 변경 서비스로직
-     * @param fcmTokenDto
+     * @param fcmTokenDto fcmTokenDto(fcmToken)
      * @author 배태현
      */
     @Override

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -181,16 +181,15 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 전화번호를 변경하는 서비스 로직
-     * @param phoneNumberChangeDto phoneNumberChangeDto(username, newPhoneNumber)
+     * @param phoneNumberChangeDto phoneNumberChangeDto(newPhoneNumber)
      * @author 배태현
      */
     @Override
     @Transactional
     public void changePhoneNumber(PhoneNumberChangeDto phoneNumberChangeDto) {
-        MemberEntity memberEntity = memberRepository.findByUsername(phoneNumberChangeDto.getUsername());
-        if (memberEntity == null) throw new MemberNotFoundException();
+        MemberEntity currentUser = currentUserUtil.getCurrentUser();
 
-        memberEntity.updatePhoneNumber(phoneNumberChangeDto.getNewPhoneNumber());
+        currentUser.updatePhoneNumber(phoneNumberChangeDto.getNewPhoneNumber());
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/jwt/RefreshTokenServiceImpl.java
@@ -27,7 +27,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     /**
      * accessToken에서 가져온 username과, refreshToken으로 새로운 accessToken과 refreshToken을 생성하는 메서드
      * @param nickname, refreshToken
-     * @return Map<String, String> username, newAccessToken, newRefreshToken
+     * @return Map<String, String> (username, newAccessToken, newRefreshToken)
      * @author 배태현
      */
     @Override

--- a/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
@@ -54,7 +54,7 @@ public class CertifiedMemberControllerTest {
 
         AuthDto deleteUserDto = AuthDto.builder()
                 .username("@BaeTul")
-                .password("1234")
+                .password("12341234")
                 .build();
 
         String content = objectMapper.writeValueAsString(deleteUserDto);

--- a/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/CertifiedMemberControllerTest.java
@@ -65,7 +65,7 @@ public class CertifiedMemberControllerTest {
 
         actions
                 .andDo(print())
-                .andExpect(status().isNoContent()); //http status 204
+                .andExpect(status().isOk()); //http status 200
     }
 
     @Test

--- a/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
@@ -50,7 +50,7 @@ public class MemberControllerTest {
     public void signupTest() throws Exception {
         MemberDto memberDto = MemberDto.builder()
                 .username("@bBbB")
-                .password("1234")
+                .password("qwerqwer")
                 .phoneNumber("01008090809")
                 .build();
 
@@ -71,7 +71,7 @@ public class MemberControllerTest {
     public void signInTest() throws Exception {
         AuthDto loginDto = AuthDto.builder()
                 .username("@Json")
-                .password("1234")
+                .password("1234qwer")
                 .build();
 
         String content = objectMapper.writeValueAsString(loginDto);
@@ -117,27 +117,12 @@ public class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("username 찾기 테스트")
-    public void findUsernameTest() throws Exception {
-
-        String content = objectMapper.writeValueAsString("01012341234");
-
-        final ResultActions actions = mvc.perform(post("/v1/member/find/username")
-                .content(content)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        actions
-                .andDo(print())
-                .andExpect(status().isOk());
-    }
-
-    @Test
     @DisplayName("비밀번호 변경 테스트")
     public void pwdChangeTest() throws Exception {
 
         PasswordChangeDto passwordChangeDto = PasswordChangeDto.builder()
                 .username("@Baeeeee")
-                .newPassword("string")
+                .newPassword("string1234")
                 .build();
 
         String content = objectMapper.writeValueAsString(passwordChangeDto);

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 import java.util.Map;
 
@@ -262,37 +263,19 @@ public class MemberServiceTest {
 
         //when //then
         if (currentUser != null) {
-            MemberEntity findByUsername = memberRepository.findByUsername("@Baetaehyeon");
-            assertEquals("01012345678", findByUsername.getPhoneNumber());
+            assertEquals("01000000000", currentUser.getPhoneNumber());
 
             memberService.changePhoneNumber(
                     PhoneNumberChangeDto.builder()
-                            .username("@Baetaehyeon")
                             .newPhoneNumber("01049977055")
                             .build()
             );
 
-            MemberEntity memberEntity = memberRepository.findByUsername("@Baetaehyeon");
-            assertEquals("01049977055", memberEntity.getPhoneNumber());
+            assertEquals("01049977055", currentUser.getPhoneNumber());
 
         } else {
             Assertions.fail("전화번호 변경 테스트 실패");
         }
-    }
-
-    @Test
-    @DisplayName("changePhoneNumber에서 MemberNotFoundException이 터지나요?")
-    public void changePhoneNumberException() {
-        //given //when //then
-        assertThrows(
-                MemberNotFoundException.class,
-                () -> memberService.changePhoneNumber(
-                        PhoneNumberChangeDto.builder()
-                                .username("NoUser")
-                                .newPhoneNumber("01013131313")
-                                .build()
-                )
-        );
     }
 
     @Test

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -173,29 +173,6 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("username을 찾는 테스트")
-    public void findUsername() {
-        //given
-        String phoneNumber = "01012345678";
-
-        //when
-        String username = memberService.findUsername(phoneNumber);
-
-        //then
-        assertEquals("@Baetaehyeon", username);
-    }
-
-    @Test
-    @DisplayName("회원가입된 유저가 아닐 때 Exception이 터지나요?")
-    public void findUsernameException() {
-        //given //when //then
-        assertThrows(
-                MemberNotFoundException.class,
-                () -> memberService.findUsername("NoUser")
-        );
-    }
-
-    @Test
     @DisplayName("Username 변경 테스트")
     public void changeUsername() {
         //given


### PR DESCRIPTION
### 제가 한 일이에요 !
* 컨트롤러 / 서비스로직 주석 수정/보완
* 회원탈퇴 컨트롤러 Response Http Status 204 -> 200으로 지정
* 아이디(username) 찾기 로직 삭제
> 아이디(username)찾기 로직을 삭제한 이유는 이와같습니다 (iOS와 소통 한 결과...)
> 1. 아이디(username) 재설정 기능이 있다. (로그인 후 사용가능한 기능)
> 2. iOS 단에서 기능이 없는 줄 알고 페이지 자체를 만들지 않고 서버에서만 만든 기능이라고 합니다. (현 PR 서버 부분에서 기능 삭제함)

> 여러분의 의견 듣고싶습니다. 
> (개인적으로 로그인 하지 않았을 때 아이디(username)를 재설정하던지, 찾는 기능이 필요하다고 생각합니다.)

한 PR 에 많은 변동사항 죄송합니다 ! 
작업하다보니 많아졌네요 😓