### PR TITLE
FCM push 알람에 payloads를 추가할 수 있게 로직추가

### DIFF
--- a/src/main/java/com/server/EZY/notification/FcmMessage.java
+++ b/src/main/java/com/server/EZY/notification/FcmMessage.java
@@ -2,6 +2,8 @@ package com.server.EZY.notification;
 
 import lombok.*;
 
+import java.util.Map;
+
 public class FcmMessage {
     @Getter @Builder
     @AllArgsConstructor
@@ -15,5 +17,7 @@ public class FcmMessage {
     public static class FcmRequest{
         private String title;
         private String body;
+
+        private Map<String, String> payloads;
     }
 }

--- a/src/main/java/com/server/EZY/notification/FcmMessage.java
+++ b/src/main/java/com/server/EZY/notification/FcmMessage.java
@@ -15,10 +15,5 @@ public class FcmMessage {
     public static class FcmRequest{
         private String title;
         private String body;
-
-        public void setRequest(String title, String body){
-            this.title = title;
-            this.body = body;
-        }
     }
 }

--- a/src/main/java/com/server/EZY/notification/FcmMessage.java
+++ b/src/main/java/com/server/EZY/notification/FcmMessage.java
@@ -2,6 +2,7 @@ package com.server.EZY.notification;
 
 import lombok.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class FcmMessage {
@@ -18,6 +19,7 @@ public class FcmMessage {
         private String title;
         private String body;
 
-        private Map<String, String> payloads;
+        @Builder.Default
+        private Map<String, String> payloads = new HashMap<>();
     }
 }

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -1,15 +1,12 @@
 package com.server.EZY.notification.service;
 
-import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.*;
 import com.server.EZY.notification.FcmMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -42,46 +42,6 @@ public class FirebaseMessagingService {
     }
 
     /**
-     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
-     * @param fcmMessage FCM메시지를 보내기 위한 DTO
-     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
-     * @param payload 해당 push 알람에대한 추가적인 페이로드
-     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
-     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
-     * @author 정시원
-     */
-    @Async
-    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload) {
-        return sendToToken(fcmMessage, fcmToken, payload, false);
-    }
-
-    /**
-     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
-     * @param fcmMessage FCM메시지를 보내기 위한 DTO
-     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
-     * @param payload 해당 push 알람에대한 추가적인 페이로드
-     * @param isTest 해당 FCM push 알람 요청을 테스트로 진행 할 여부
-     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
-     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
-     * @author 정시원
-     */
-    @Async
-    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload, boolean isTest) {
-        Message message = Message.builder()
-                .setNotification(
-                        Notification.builder()
-                                .setTitle(fcmMessage.getTitle())
-                                .setBody(fcmMessage.getBody())
-                                .build()
-                )
-                .setToken(fcmToken)
-                .putAllData(payload)
-                .build();
-
-        return firebaseMessaging.sendAsync(message, isTest);
-    }
-
-    /**
      * 여러 기기에 메시지를 전송하는 method
      * @param fcmMessage
      * @param tokens
@@ -128,4 +88,45 @@ public class FirebaseMessagingService {
         // [END apns_message]
         return message;
     }
+
+    //  FCM 비동기 처리는 추후 개선할 예정
+//    /**
+//     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
+//     * @param fcmMessage FCM메시지를 보내기 위한 DTO
+//     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
+//     * @param payload 해당 push 알람에대한 추가적인 페이로드
+//     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
+//     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
+//     * @author 정시원
+//     */
+//    @Async
+//    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload) {
+//        return sendToToken(fcmMessage, fcmToken, payload, false);
+//    }
+//
+//    /**
+//     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
+//     * @param fcmMessage FCM메시지를 보내기 위한 DTO
+//     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
+//     * @param payload 해당 push 알람에대한 추가적인 페이로드
+//     * @param isTest 해당 FCM push 알람 요청을 테스트로 진행 할 여부
+//     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
+//     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
+//     * @author 정시원
+//     */
+//    @Async
+//    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload, boolean isTest) {
+//        Message message = Message.builder()
+//                .setNotification(
+//                        Notification.builder()
+//                                .setTitle(fcmMessage.getTitle())
+//                                .setBody(fcmMessage.getBody())
+//                                .build()
+//                )
+//                .setToken(fcmToken)
+//                .putAllData(payload)
+//                .build();
+//
+//        return firebaseMessaging.sendAsync(message, isTest);
+//    }
 }

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -24,16 +24,24 @@ public class FirebaseMessagingService {
      */
     public void sendToToken (FcmMessage.FcmRequest fcmMessage, String token) throws FirebaseMessagingException {
         // FirebaseMessging으로 푸시알람을 보내기 위한 객체
-        Message message = Message.builder()
+        Message message;
+
+        Message.Builder messageBuilder = Message.builder()
                 .setNotification(
                         Notification.builder()
                                 .setTitle(fcmMessage.getTitle())
                                 .setBody(fcmMessage.getBody())
                                 .build()
                 )
-                .setToken(token)
-                .putAllData(fcmMessage.getPayloads())
-                .build();
+                .setToken(token);
+        // payloads가 null이라면 Message객체에 payloads를 put하지 않는다.
+        if(fcmMessage.getPayloads().isEmpty()) {
+            message = messageBuilder.build();
+        }else {
+            message = messageBuilder
+                    .putAllData(fcmMessage.getPayloads())
+                    .build();
+        }
 
         String response = firebaseMessaging.send(message);
         log.info("Successfully sent message: {}", response);

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -35,6 +35,7 @@ public class FirebaseMessagingService {
                                 .build()
                 )
                 .setToken(token)
+                .putAllData(fcmMessage.getPayloads())
                 .build();
 
         String response = firebaseMessaging.send(message);

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -24,24 +24,16 @@ public class FirebaseMessagingService {
      */
     public void sendToToken (FcmMessage.FcmRequest fcmMessage, String token) throws FirebaseMessagingException {
         // FirebaseMessging으로 푸시알람을 보내기 위한 객체
-        Message message;
-
-        Message.Builder messageBuilder = Message.builder()
+        Message message = Message.builder()
                 .setNotification(
                         Notification.builder()
                                 .setTitle(fcmMessage.getTitle())
                                 .setBody(fcmMessage.getBody())
                                 .build()
                 )
-                .setToken(token);
-        // payloads가 null이라면 Message객체에 payloads를 put하지 않는다.
-        if(fcmMessage.getPayloads().isEmpty()) {
-            message = messageBuilder.build();
-        }else {
-            message = messageBuilder
-                    .putAllData(fcmMessage.getPayloads())
-                    .build();
-        }
+                .setToken(token)
+                .putAllData(fcmMessage.getPayloads())
+                .build();
 
         String response = firebaseMessaging.send(message);
         log.info("Successfully sent message: {}", response);

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -1,12 +1,15 @@
 package com.server.EZY.notification.service;
 
+import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.*;
 import com.server.EZY.notification.FcmMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,46 @@ public class FirebaseMessagingService {
 
         String response = firebaseMessaging.send(message);
         log.info("Successfully sent message: {}", response);
+    }
+
+    /**
+     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
+     * @param fcmMessage FCM메시지를 보내기 위한 DTO
+     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
+     * @param payload 해당 push 알람에대한 추가적인 페이로드
+     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
+     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
+     * @author 정시원
+     */
+    @Async
+    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload) {
+        return sendToToken(fcmMessage, fcmToken, payload, false);
+    }
+
+    /**
+     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
+     * @param fcmMessage FCM메시지를 보내기 위한 DTO
+     * @param fcmToken FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
+     * @param payload 해당 push 알람에대한 추가적인 페이로드
+     * @param isTest 해당 FCM push 알람 요청을 테스트로 진행 할 여부
+     * @return 해당 알람을 비동기로 처리하는({@link ApiFuture})
+     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
+     * @author 정시원
+     */
+    @Async
+    public ApiFuture<String> sendToToken (FcmMessage.FcmRequest fcmMessage, String fcmToken, Map<String, String> payload, boolean isTest) {
+        Message message = Message.builder()
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(fcmMessage.getTitle())
+                                .setBody(fcmMessage.getBody())
+                                .build()
+                )
+                .setToken(fcmToken)
+                .putAllData(payload)
+                .build();
+
+        return firebaseMessaging.sendAsync(message, isTest);
     }
 
     /**


### PR DESCRIPTION
### 한 일
#### 1. `FirebaseMessagingService.sendToToken`에서 push알람에 payloads를 보낼 수 있게 로직을 추가했습니다.
그러기 위해 `FcmMessage.FcmRequest`에 `Map<String, String payloads` 필드를 추가했습니다.

이는 심부름 수락/거절에 사용될 예정이고(해당 심부름에 대한 idx를 넘겨줄 예정) 아마 심부름 보내기 로직 이외에도 이후 확장에 필요할 거 같아 추가했습니다.

#### 2. `FcmMessage.FcmRequest`를 불변 객체로 만들기 위해 사용하지 않는 setter제거

### 코드리뷰 원해요
- 제가 작성한 로직에 대한 피드백
- 변수명 클래스명 등등 명명에 대한 피드백