### PR TITLE
비밀번호 재설정 취약점 보완

### DIFF
--- a/src/main/java/com/server/EZY/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.server.EZY.model.member.controller;
 
 import com.server.EZY.model.member.dto.AuthDto;
 import com.server.EZY.model.member.dto.PasswordChangeDto;
+import com.server.EZY.model.member.dto.PasswordChangeInfoDto;
 import com.server.EZY.model.member.dto.MemberDto;
 import com.server.EZY.model.member.service.MemberService;
 import com.server.EZY.response.ResponseService;
@@ -83,16 +84,30 @@ public class MemberController {
     }
 
     /**
-     * 비밀번호를 재설정 controller
-     * @param passwordChangeDto passwordChangeDto(username, newPassword)
+     * 비밀번호 재설정 전 회원정보, 인증번호를 전송하는 controller
+     * @param passwordChangeInfoDto passwordChangeDto(username, newPassword)
      * @return CommonResult - SuccessResult
      * @author 배태현
      */
-    @PutMapping ("/change/password")
-    @ApiOperation(value = "비밀번호 재설정", notes = "비밀번호 재설정")
+    @PostMapping ("/info/change/password")
+    @ApiOperation(value = "비밀번호 재설정 전 정보, 인증번호 보내기", notes = "비밀번호 재설정 전 정보, 인증번호 보내기")
     @ResponseStatus( HttpStatus.OK )
+    public CommonResult passwordChangeInfo(@Valid @RequestBody PasswordChangeInfoDto passwordChangeInfoDto) {
+        memberService.passwordInfo(passwordChangeInfoDto);
+        return responseService.getSuccessResult();
+    }
+
+    /**
+     * 인증번호 인증, 비밀번호 재설정 controller
+     * @param passwordChangeDto passwordChangeDto(key, username, newPassword)
+     * @return CommonResult - SuccessResult
+     * @author 배태현
+     */
+    @PutMapping("/change/password")
+    @ApiOperation(value = "인증번호 인증, 비밀번호 재설정", notes = "인증번호 인증, 비밀번호 재설정")
+    @ResponseStatus ( HttpStatus.OK )
     public CommonResult passwordChange(@Valid @RequestBody PasswordChangeDto passwordChangeDto) {
-        memberService.changePassword(passwordChangeDto);
+        memberService.keyAuthAndChangePassword(passwordChangeDto);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/EZY/model/member/dto/PasswordChangeInfoDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PasswordChangeInfoDto.java
@@ -8,16 +8,12 @@ import javax.validation.constraints.Size;
 
 @Getter @Setter @Builder
 @NoArgsConstructor @AllArgsConstructor
-public class PasswordChangeDto {
+public class PasswordChangeInfoDto {
 
     @NotBlank
     @Pattern(regexp = "^@[a-zA-Z]*$")
     @Size(min = 1, max = 10)
     private String username;
-
-//    @NotBlank
-//    @Size(min = 8)
-//    private String newPassword;
 
     @NotBlank
     private String phoneNumber;

--- a/src/main/java/com/server/EZY/model/member/dto/PasswordChangeInfoDto.java
+++ b/src/main/java/com/server/EZY/model/member/dto/PasswordChangeInfoDto.java
@@ -11,15 +11,14 @@ import javax.validation.constraints.Size;
 public class PasswordChangeDto {
 
     @NotBlank
-    @Size(min = 4, max = 4)
-    private String key; //문자로 받은 인증번호
-
-    @NotBlank
     @Pattern(regexp = "^@[a-zA-Z]*$")
     @Size(min = 1, max = 10)
     private String username;
 
+//    @NotBlank
+//    @Size(min = 8)
+//    private String newPassword;
+
     @NotBlank
-    @Size(min = 8)
-    private String newPassword;
+    private String phoneNumber;
 }

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -3,7 +3,6 @@ package com.server.EZY.model.member.service;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.dto.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 
@@ -21,7 +20,9 @@ public interface MemberService {
 
     void changeUsername(UsernameChangeDto usernameChangeDto);
 
-    void changePassword(PasswordChangeDto passwordChangeDto);
+    void passwordInfo(PasswordChangeInfoDto passwordChangeInfoDto);
+
+    void keyAuthAndChangePassword(PasswordChangeDto passwordChangeDto);
 
     void changePhoneNumber(PhoneNumberChangeDto phoneNumberChangeDto);
 

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -108,7 +108,6 @@ public class MemberServiceImpl implements MemberService {
     /**
      * 전화번호로 인증번호를 보내는 서비스 로직
      * @param phoneNumber
-     * @exception - phoneNumber로 member를 찾을 수 없다면 UserNotFoundException
      * @author 배태현
      */
     @Override
@@ -116,13 +115,37 @@ public class MemberServiceImpl implements MemberService {
         String authKey = keyUtil.getKey(4);
         redisUtil.setDataExpire(authKey, authKey, KEY_EXPIRATION_TIME);
 
+        sendMessage(phoneNumber, authKey);
+    }
+
+    /**
+     * 비밀번호를 변경하기 위해 인증번호를 보내는 메서드
+     * @param phoneNumber
+     * @author 배태현
+     */
+    private void sendPasswordAuthKey(String phoneNumber) {
+        MemberEntity findMember = memberRepository.findByPhoneNumber(phoneNumber);
+        if (findMember == null) throw new MemberNotFoundException();
+
+        String authKey = keyUtil.getKey(4);
+        redisUtil.setDataExpire(findMember.getUsername(), authKey, KEY_EXPIRATION_TIME);
+        sendMessage(phoneNumber, authKey);
+    }
+
+    /**
+     * 메세지를 보내는 부분을 메서드로 분리
+     * @param phoneNumber
+     * @param authKey
+     * @author 배태현
+     */
+    private void sendMessage(String phoneNumber, String authKey) {
         Message coolsms = new Message(apiKey, apiSecret);
         HashMap<String, String> params = new HashMap<String, String>();
 
         params.put("to", phoneNumber);
         params.put("from", "07080283503");
         params.put("type", "SMS");
-        params.put("text", "[EZY] 인증번호 "+authKey+" 를 입력하세요.");
+        params.put("text", "[EZY] 인증번호 "+ authKey +" 를 입력하세요.");
         params.put("app_version", "test app 1.2");
 
         try {
@@ -138,6 +161,7 @@ public class MemberServiceImpl implements MemberService {
     /**
      * 사용자가 문자로 받은 인증번호를 검증하는 서비스 로직
      * @param key
+     * @exception InvalidAuthenticationNumberException 인증번호가 일치하지 않을 때
      * @return test코드 작성을 위한 key 반환
      * @author 배태현
      */
@@ -146,6 +170,45 @@ public class MemberServiceImpl implements MemberService {
         if (key.equals(redisUtil.getData(key))) {
             redisUtil.deleteData(key);
             return key;
+        } else {
+            throw new InvalidAuthenticationNumberException();
+        }
+    }
+
+    /**
+     * 비밀번호를 변경하기 전 정보를 받고 인증번호를 전송하는 서비스 로직
+     * @param passwordChangeInfoDto passwordChangeDto(username, phoneNumber)
+     * @exception Exception username과 password가 동일한 회원의 정보가 아닐 때
+     * @author 배태현
+     */
+    @Override
+    @Transactional
+    public void passwordInfo(PasswordChangeInfoDto passwordChangeInfoDto) {
+        MemberEntity memberEntity = memberRepository.findByUsername(passwordChangeInfoDto.getUsername());
+        if (memberEntity == null) throw new MemberNotFoundException();
+
+        if (memberEntity.getPhoneNumber().equals(passwordChangeInfoDto.getPhoneNumber())) {
+            sendPasswordAuthKey(passwordChangeInfoDto.getPhoneNumber()); //비밀번호 변경용 인증번호 메세지 전송
+        } else {
+            throw new IllegalArgumentException("변경하려는 회원의 정보를 다시 확인해주세요.");
+        }
+    }
+
+    /**
+     * 인증번호, 새로운 비밀번호를 받아 인증번호가 일치할 시 비밀번호가 변경되는 서비스로직
+     * @param passwordChangeDto passwordChangeDto(key, username, newPassword)
+     * @exception InvalidAuthenticationNumberException 인증번호가 일치하지 않을 때
+     * @author 배태현
+     */
+    @Override
+    @Transactional
+    public void keyAuthAndChangePassword(PasswordChangeDto passwordChangeDto) {
+        if (passwordChangeDto.getKey().equals(redisUtil.getData(passwordChangeDto.getUsername()))) {
+            MemberEntity findMember = memberRepository.findByUsername(passwordChangeDto.getUsername());
+            findMember.updatePassword(
+                    passwordEncoder.encode(passwordChangeDto.getNewPassword())
+            );
+            redisUtil.deleteData(passwordChangeDto.getKey());
         } else {
             throw new InvalidAuthenticationNumberException();
         }
@@ -163,20 +226,6 @@ public class MemberServiceImpl implements MemberService {
         if (memberEntity == null) throw new MemberNotFoundException();
 
         memberEntity.updateUsername(usernameChangeDto.getNewUsername());
-    }
-
-    /**
-     * 비밀번호를 변경하는 서비스 로직
-     * @param passwordChangeDto passwordChangeDto(username, newPassword)
-     * @author 배태현
-     */
-    @Override
-    @Transactional
-    public void changePassword(PasswordChangeDto passwordChangeDto) {
-        MemberEntity memberEntity = memberRepository.findByUsername(passwordChangeDto.getUsername());
-        if (memberEntity == null) throw new MemberNotFoundException();
-
-        memberEntity.updatePassword(passwordEncoder.encode(passwordChangeDto.getNewPassword()));
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -182,7 +182,6 @@ public class MemberServiceImpl implements MemberService {
      * @author 배태현
      */
     @Override
-    @Transactional
     public void passwordInfo(PasswordChangeInfoDto passwordChangeInfoDto) {
         MemberEntity memberEntity = memberRepository.findByUsername(passwordChangeInfoDto.getUsername());
         if (memberEntity == null) throw new MemberNotFoundException();

--- a/src/main/java/com/server/EZY/security/SecurityConfig.java
+++ b/src/main/java/com/server/EZY/security/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v1/member/signup").permitAll()//
                 .antMatchers("/v1/member/find/username").permitAll()//
                 .antMatchers("/v1/member/change/username").authenticated()//
+                .antMatchers("/v1/member/info/change/password").permitAll()//
                 .antMatchers("/v1/member/change/password").permitAll()//
                 .antMatchers("/v1/member/auth").permitAll()//
                 .antMatchers("/v1/member/auth/check").permitAll()//

--- a/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/EZY/model/member/controller/MemberControllerTest.java
@@ -2,22 +2,17 @@ package com.server.EZY.model.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.EZY.model.member.dto.AuthDto;
-import com.server.EZY.model.member.dto.PasswordChangeDto;
+import com.server.EZY.model.member.dto.PasswordChangeInfoDto;
 import com.server.EZY.model.member.dto.MemberDto;
-import com.server.EZY.model.member.dto.UsernameChangeDto;
 import com.server.EZY.model.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -117,17 +112,17 @@ public class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("비밀번호 변경 테스트")
-    public void pwdChangeTest() throws Exception {
+    @DisplayName("비밀번호 변경 전 정보, 인증번호 전송 테스트")
+    public void pwdInfoTest() throws Exception {
 
-        PasswordChangeDto passwordChangeDto = PasswordChangeDto.builder()
+        PasswordChangeInfoDto passwordChangeInfoDto = PasswordChangeInfoDto.builder()
                 .username("@Baeeeee")
-                .newPassword("string1234")
+                .phoneNumber("01049977055")
                 .build();
 
-        String content = objectMapper.writeValueAsString(passwordChangeDto);
+        String content = objectMapper.writeValueAsString(passwordChangeInfoDto);
 
-        final ResultActions actions = mvc.perform(put("/v1/member/change/password")
+        final ResultActions actions = mvc.perform(post("/v1/member/info/change/password")
                 .content(content)
                 .contentType(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.List;
 import java.util.Map;
 
@@ -215,41 +214,15 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("비밀번호 변경 테스트")
-    public void changePasswordTest() {
-        //given
-        MemberEntity currentUser = currentUser();
-
-        PasswordChangeDto passwordChangeDto = PasswordChangeDto.builder()
-                .username("@Baetaehyeon")
-                .newPassword("20040809")
-                .build();
-
-        //when //then
-        if (currentUser != null) {
-            MemberEntity findByUsername = memberRepository.findByUsername(passwordChangeDto.getUsername());
-            assertTrue(passwordEncoder.matches("0809", findByUsername.getPassword()));
-
-            memberService.changePassword(passwordChangeDto);
-
-            MemberEntity memberEntity = memberRepository.findByUsername(passwordChangeDto.getUsername());
-            assertTrue(passwordEncoder.matches(passwordChangeDto.getNewPassword(), memberEntity.getPassword()));
-
-        } else {
-            Assertions.fail("비밀번호 변경 테스트 실패");
-        }
-    }
-
-    @Test
     @DisplayName("찾을 수 없는 user Exception이 터지나요?")
     public void changePasswordException() {
         //given //when //then
         assertThrows(
                 MemberNotFoundException.class,
-                () -> memberService.changePassword(
-                        PasswordChangeDto.builder()
+                () -> memberService.passwordInfo(
+                        PasswordChangeInfoDto.builder()
                                 .username("NoUser")
-                                .newPassword("0000")
+                                .phoneNumber("01049977055")
                                 .build()
                 )
         );


### PR DESCRIPTION
### 제가 한 일이에요 !
* 비밀번호 재설정 비즈니스 로직, 설계 변경
    * 메세지 보내는 로직 메서드로 분리
    * 일반적인 인증번호 전송, 비밀번호 재설정을 위한 인증번호 전송 로직 분리
    > 일반적인 인증번호 전송로직과 비밀번호 변경을 위한 인증번호전송 로직은 
    **인증번호를 redis에 저장하는 과정에서 차이**가 생기며
    **비밀번호 변경을 위한 인증번호 전송 로직은 입력된 전화번호가 EZY회원의 전화번호인지 체킹하는 로직이 포함**되어있습니다 !

현재 구현된 flow는 다음과 같습니다.
1. username, phoneNumber 서버로 전송, phoneNumber로 인증번호 보내기
2. 인증번호 인증, 변경할 비밀번호 입력

### 알려드립니다 !
> 하나의 메서드에서 하나의 책임만을 담당하진 못하지만
이걸 분리하게 되면 메서드간 아무 연관도 없기 때문에 비밀번호 재설정 로직을 구현하지 못하게되어
현재처럼 구현하게 되었음을 알려드립니다 😭

**비밀번호 재설정 로직에서 사용하는 인증번호 보내기, 인증번호 인증 로직**은
**회원가입 때 전화번호를 인증하는 로직과 다름을 알려드립니다 !**

### 리뷰 받고싶어요 !
더 좋은 방법, 설계가 있다면 그런 방법으로 바꾸고싶어요, 리뷰 부탁드립니다 !