### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -7,6 +7,7 @@ import com.server.EZY.model.plan.errand.ErrandStatusEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
 import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import com.server.EZY.model.plan.errand.repository.ErrandRepository;
+import com.server.EZY.model.plan.errand.repository.ErrandStatusRepository;
 import com.server.EZY.notification.dto.FcmSourceDto;
 import com.server.EZY.notification.enum_type.FcmPurposeType;
 import com.server.EZY.notification.enum_type.FcmRole;
@@ -28,6 +29,7 @@ public class ErrandServiceImpl implements ErrandService{
     private final MemberRepository memberRepository;
     private final ErrandRepository errandRepository;
     private final ActiveFcmFilterService activeFcmFilterService;
+    private final ErrandStatusRepository errandStatusRepository;
 
     /**
      * 이 메서드는 심부름을 전송(저장) 할 때 사용하는 비즈니스 로직입니다.
@@ -44,13 +46,19 @@ public class ErrandServiceImpl implements ErrandService{
         MemberEntity sender = currentUserUtil.getCurrentUser();
         MemberEntity recipient = memberRepository.findByUsername(errandSetDto.getRecipient());
 
-        ErrandStatusEntity errandStatusEntity = ErrandStatusEntity.builder()
+        // 심부름 세부사항을 세팅한다.
+        ErrandStatusEntity errandDetails = ErrandStatusEntity.builder()
                 .senderIdx(sender.getMemberIdx())
                 .recipientIdx(recipient.getMemberIdx())
                 .errandResponseStatus(ErrandResponseStatus.NOT_READ)
                 .build();
 
-        ErrandEntity savedErrandEntity = errandRepository.save(errandSetDto.saveToEntity(sender, errandStatusEntity));
+        /**
+         * savedErrandDetails: 심부름에 대한 상세정보를 저장한다.
+         * savedErrandEntity: 심부름을 저장한다.
+         */
+        ErrandStatusEntity savedErrandDetails = errandStatusRepository.save(errandDetails);
+        ErrandEntity savedErrandEntity = errandRepository.save(errandSetDto.saveToEntity(sender, savedErrandDetails));
 
         // 여기서 FCM 스펙을 정의 함.
         FcmSourceDto fcmSourceDto = FcmSourceDto.builder()

--- a/src/main/java/com/server/EZY/notification/service/feature/ActiveFcmFilterService.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/ActiveFcmFilterService.java
@@ -31,7 +31,7 @@ public class ActiveFcmFilterService {
      * @throws FirebaseMessagingException
      */
     private void checkFcmPurpose(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
-        log.info("===========목적이 {}로 인식 됐습니다.", fcmSourceDto.getFcmPurposeType());
+        log.info("===========목적이 {}(으)로 인식 됐습니다.", fcmSourceDto.getFcmPurposeType());
         switch (fcmSourceDto.getFcmPurposeType()){
             case 심부름: checkErrandRole(fcmSourceDto);
                 break;
@@ -46,7 +46,7 @@ public class ActiveFcmFilterService {
      * @throws FirebaseMessagingException
      */
     private void checkErrandRole(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
-        log.info("===========역할이 {}로 인식 됐습니다.", fcmSourceDto.getFcmRole());
+        log.info("===========역할이 {}(으)로 인식 됐습니다.", fcmSourceDto.getFcmRole());
         switch (fcmSourceDto.getFcmRole()){
             case 보내는사람: fcmMakerService.sendErrandFcm(fcmSourceDto);
         }


### PR DESCRIPTION
### 커밋내용
1. 심부름 저장 로직에 대해 자세한 주석을 달았음
2. 심부름 세부사항 저장 로직을 추가 함

### 요구사항
@siwony 
지금 `ErrandStatusEntity` 명명이 마음에 조금 안들어요. 사용을 안하다가 하니깐 클래스 명명에 대한 불편함이 생겼습니다. 
이유는 간단합니다 Status(상태)는 해당 `ErrandStatusEntity`의 기능을 포괄적으로 담아내지 못합니다.
해당 엔티티의 클래스명을 `ErrandDetailsEntity`로 바꾸면 클래스가 하는 일이 더 정확하게 표현 될 것 같습니다.

`ErrandDetailsEntity`로 바꾼다면 "Details(세부사항들) 를 기술하고 ErrandEntity를 저장한다." 이렇게 해석되어 비즈니스 로직에서도 좋은 경험을 줄거라 생각합니다. 실제로 필드와(수신자, 발신자, 상태..etc) 어울립니다!

#### 해당 비즈니스 로직은 미리 변수명을 바꿔뒀습니다. 참고하세요!
<img width="1118" alt="Screen Shot 2021-10-15 at 5 56 14 PM" src="https://user-images.githubusercontent.com/67095821/137461047-33561469-d83d-420b-bde6-db4593972ba9.png">