### PR TITLE
전화번호 중복 여부 확인

### DIFF
--- a/src/main/java/com/server/EZY/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/EZY/model/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.server.EZY.model.member.service.MemberService;
 import com.server.EZY.response.ResponseService;
 import com.server.EZY.response.result.CommonResult;
 import com.server.EZY.response.result.SingleResult;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,18 @@ public class MemberController {
     @ResponseStatus( HttpStatus.OK )
     public SingleResult checkUsernameExist(@Valid @RequestBody UsernameDto usernameDto) {
         return responseService.getSingleResult(memberService.isExistUsername(usernameDto.getUsername()));
+    }
+
+    /**
+     * 이미 가입된 phoneNumber인지 check 해주는 controller
+     * @param phoneNumberDto phoneNumber
+     * @return CommonResult - SuccessResult
+     */
+    @PostMapping("/verified/phone")
+    @ApiOperation(value = "phoneNumber 존재 여부 확인", notes = "phoneNumber 존재 여부 확인")
+    @ResponseStatus( HttpStatus.OK )
+    public SingleResult checkPhoneNumberExist(@Valid @RequestBody PhoneNumberDto phoneNumberDto) {
+        return responseService.getSingleResult(memberService.isExistPhoneNumber(phoneNumberDto.getPhoneNumber()));
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
@@ -8,10 +8,9 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
-    // MyUserDetails 에서 사용.
     MemberEntity findByUsername(String username);
-    // UserService 에서 사용.
     boolean existsByUsername(String username);
+    boolean existsByPhoneNumber(String phoneNumber);
     Optional<MemberEntity> findByPhoneNumber(String phoneNumber);
 }
 

--- a/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/EZY/model/member/repository/MemberRepository.java
@@ -11,6 +11,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     MemberEntity findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByPhoneNumber(String phoneNumber);
+    boolean existsByUsernameAndPhoneNumber(String username, String phoneNumber);
     Optional<MemberEntity> findByPhoneNumber(String phoneNumber);
 }
 

--- a/src/main/java/com/server/EZY/model/member/service/MemberService.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberService.java
@@ -10,6 +10,8 @@ public interface MemberService {
 
     boolean isExistUsername(String username);
 
+    boolean isExistPhoneNumber(String phoneNumber);
+
     MemberEntity signup(MemberDto memberDto);
 
     Map<String, String> signin(AuthDto loginDto);

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -50,6 +50,17 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
+     * 이미 가입된 phoneNumber인지 체크해주는 서비스로직
+     * @param phoneNumber phoneNumber
+     * @author 배태현
+     * @return 이미 가입된 phoneNumber라면 true반환 / 이미 가입된 phoneNumber가 아니라면 false반환
+     */
+    @Override
+    public boolean isExistPhoneNumber(String phoneNumber) {
+        return memberRepository.existsByPhoneNumber(phoneNumber);
+    }
+
+    /**
      * 회원가입 서비스 로직
      * @param memberDto memberDto(username, password, phoneNumber, fcmToken)
      * @return - save가 완료되면 test코드를 위한 memberEntity를 반환합니다.

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -65,7 +65,7 @@ public class MemberServiceImpl implements MemberService {
      * 회원가입 서비스 로직
      * @param memberDto memberDto(username, password, phoneNumber, fcmToken)
      * @return - save가 완료되면 test코드를 위한 memberEntity를 반환합니다.
-     * @exception - else, 이미 존재하는 정보의 회원이라면 MemberAlreadyExistException
+     * @exception - 이미 존재하는 정보의 회원이라면 MemberAlreadyExistException
      * @author 배태현
      */
     @Override

--- a/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/member/service/MemberServiceImpl.java
@@ -41,7 +41,6 @@ public class MemberServiceImpl implements MemberService {
     /**
      * 이미 가입된 username인지 체크해주는 서비스로직
      * @param username username
-     * @exception - 이미 가입된 username일 때 MemberAlreadyExistException
      * @author 배태현
      * @return 이미 가입된 username이라면 true반환 / 이미 가입된 username이 아니라면 false반환
      */
@@ -59,7 +58,10 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public MemberEntity signup(MemberDto memberDto) {
-        if(!memberRepository.existsByUsername(memberDto.getUsername())){
+        boolean isExistUsername = !memberRepository.existsByUsername(memberDto.getUsername());
+        boolean isExistPhoneNumber = !memberRepository.existsByPhoneNumber(memberDto.getPhoneNumber());
+
+        if(isExistUsername && isExistPhoneNumber){
             memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
 
             return memberRepository.save(memberDto.toEntity());

--- a/src/main/java/com/server/EZY/security/SecurityConfig.java
+++ b/src/main/java/com/server/EZY/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         // Entry points
         http.authorizeRequests()
                 .antMatchers("/v1/member/verified/username").permitAll()
+                .antMatchers("/v1/member/verified/phone").permitAll()
                 .antMatchers("/v1/member/signup").permitAll()
                 .antMatchers("/v1/member/signin").permitAll()
                 .antMatchers("/v1/member/find/username").permitAll()

--- a/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/EZY/model/member/service/MemberServiceTest.java
@@ -72,13 +72,26 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("username check 테스트")
+    @DisplayName("username 중복여부 확인 테스트")
     public void checkUsernameExistTest() {
         //given
         String username = "@Baetae";
 
         //when
         boolean bool = memberService.isExistUsername(username);
+
+        //then
+        assertEquals(false, bool);
+    }
+
+    @Test
+    @DisplayName("phoneNumber 중복여부 확인 테스트")
+    public void checkPhoneNumberExistTest() {
+        //given
+        String phoneNumber = "01049977055";
+
+        //when
+        boolean bool = memberService.isExistPhoneNumber(phoneNumber);
 
         //then
         assertEquals(false, bool);


### PR DESCRIPTION
### 제가 한 일이에요 !
* 전화번호 중복여부 확인 API 개발

* 회원가입 조건문 수정
![스크린샷 2021-10-15 오후 9 55 10](https://user-images.githubusercontent.com/69895394/137490114-2a9adb65-0b31-4f97-8818-cb4984965445.png)
> `existsByUsernameAndPhoneNumber`를 사용하지 않고 
이렇게 따로 && 연산자를 이용하여 처리한 이유는
`existsByUsernameAndPhoneNumber`를 사용하면
unique속성인 username, phoneNumber 입력값 중 하나만 이미 회원인 정보와 일치했을 때에 
**이미 존재하는 회원입니다 예외**가 아닌 
**알 수 없는 에러**(sql unique에 대한 예외)로 핸들링이 되어버려 이러한 방법으로 처리했습니다.