### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -14,7 +14,7 @@ import com.server.EZY.model.plan.errand.repository.errand_status.ErrandStatusRep
 import com.server.EZY.notification.dto.FcmSourceDto;
 import com.server.EZY.notification.enum_type.FcmPurposeType;
 import com.server.EZY.notification.enum_type.FcmRole;
-import com.server.EZY.notification.service.feature.FcmMakerService;
+import com.server.EZY.notification.service.feature.FcmActiveSender;
 import com.server.EZY.util.CurrentUserUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +36,7 @@ public class ErrandServiceImpl implements ErrandService{
     private final MemberRepository memberRepository;
     private final ErrandRepository errandRepository;
     private final ErrandStatusRepository errandStatusRepository;
-    private final FcmMakerService fcmMakerService;
+    private final FcmActiveSender fcmActiveSender;
 
     /**
      * 이 메서드는 심부름을 전송(저장) 할 때 사용하는 비즈니스 로직입니다.
@@ -74,8 +74,7 @@ public class ErrandServiceImpl implements ErrandService{
                 .fcmPurposeType(FcmPurposeType.심부름)
                 .fcmRole(FcmRole.보내는사람)
                 .build();
-        // 여기서 filter 되어 fcm send 까지 완성 함.
-        fcmMakerService.sendErrandFcm(fcmSourceDto);
+        fcmActiveSender.sendRequestErrandFcmToRecipient(fcmSourceDto);
 
         return savedErrandEntity;
     }
@@ -111,7 +110,7 @@ public class ErrandServiceImpl implements ErrandService{
                 .fcmPurposeType(FcmPurposeType.심부름)
                 .fcmRole(FcmRole.받는사람)
                 .build();
-        fcmMakerService.sendAcceptErrandFcmToSender(fcmSourceDto);
+        fcmActiveSender.sendAcceptErrandFcmToSender(fcmSourceDto);
         return recipientErrand;
     }
     /**

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -24,9 +24,9 @@ public class FcmActiveSender {
      * @author 전지환
      */
     public void sendRequestErrandFcmToRecipient(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
-        FcmMessage.FcmRequest request = fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.요청);
+        FcmMessage.FcmRequest request = fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getSender(), FcmActionSelector.ErrandAction.요청);
         // 실제로 push를 전송하는 구간
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getRecipient()));
     }
 
     /**

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -1,0 +1,55 @@
+package com.server.EZY.notification.service.feature;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.server.EZY.model.member.repository.MemberRepository;
+import com.server.EZY.notification.FcmMessage;
+import com.server.EZY.notification.dto.FcmSourceDto;
+import com.server.EZY.notification.enum_type.FcmActionSelector;
+import com.server.EZY.notification.service.FirebaseMessagingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmActiveSender {
+    private final FirebaseMessagingService firebaseMessagingService;
+    private final FcmMakerService fcmMakerService;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 심부름 요청 정보를 수신자에게 알림을 보낸다.
+     *
+     * @param fcmSourceDto
+     * @throws FirebaseMessagingException
+     * @author 전지환
+     */
+    public void sendRequestErrandFcmToRecipient(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
+        FcmMessage.FcmRequest request = fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.요청);
+        // 실제로 push를 전송하는 구간
+        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+    }
+
+    /**
+     * 심부름 수락 정보를 발신자에게 알림을 보낸다.
+     *
+     * @param fcmSourceDto push알람의 생성에 기본적인 정보를 가지고 있는 DTO
+     * @throws FirebaseMessagingException 해당 push알람이 실패할 때
+     * @author 정시원
+     */
+    public void sendAcceptErrandFcmToSender(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
+        FcmMessage.FcmRequest request = fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.승인);
+        // 실제로 push를 전송하는 구간
+        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+    }
+
+    /**
+     * target, fcm target token을 찾아준다.
+     *
+     * @param recipient
+     * @return recipientFcmToken
+     * @author 전지환
+     */
+    private String findRecipientFcmToken(String recipient){
+        return memberRepository.findByUsername(recipient).getFcmToken();
+    }
+}

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmMakerService.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmMakerService.java
@@ -24,7 +24,7 @@ public class FcmMakerService {
      */
     public FcmMessage.FcmRequest makeErrandFcmMessage(FcmSourceDto fcmSourceDto, String senderOfPush, FcmActionSelector.ErrandAction errandAction){
         return FcmMessage.FcmRequest.builder()
-                .title("누군가 " + fcmSourceDto.getFcmPurposeType() + "을(를) " + errandAction + " 했어요!")
+                .title("누군가 " + fcmSourceDto.getFcmPurposeType() + "을 " + errandAction + " 했어요!")
                 .body(senderOfPush + "님이 " + errandAction+"한 "+fcmSourceDto.getFcmPurposeType()+"을 확인해보세요!")
                 .build();
     }

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmMakerService.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmMakerService.java
@@ -1,12 +1,8 @@
 package com.server.EZY.notification.service.feature;
 
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.notification.FcmMessage;
 import com.server.EZY.notification.dto.FcmSourceDto;
 import com.server.EZY.notification.enum_type.FcmActionSelector;
-import com.server.EZY.notification.service.FirebaseMessagingService;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -16,59 +12,20 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
-@AllArgsConstructor
 public class FcmMakerService {
-    private final FirebaseMessagingService firebaseMessagingService;
-    private final MemberRepository memberRepository;
-    /**
-     * [목적: 심부름, 역할: 보내는사람] 에 만족하는 메소드
-     * @param fcmSourceDto
-     * @throws FirebaseMessagingException
-     */
-    public void sendErrandFcm(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
-        FcmMessage.FcmRequest request = FcmMessage.FcmRequest.builder()
-                .title("누군가 " + fcmSourceDto.getFcmPurposeType() + "을 " + FcmActionSelector.ErrandAction.요청 + " 했어요!")
-                .body(fcmSourceDto.getSender() + "님이 " + FcmActionSelector.ErrandAction.요청+"한 "+fcmSourceDto.getFcmPurposeType()+"을 확인해보세요!")
-                .build();
-
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getRecipient()));
-    }
-
-    /**
-     * 심부름 수락 정보를 발신자에게 push알람을 보낸다.
-     * @param fcmSourceDto push알람의 생성에 기본적인 정보를 가지고 있는 DTO
-     * @throws FirebaseMessagingException 해당 push알람이 실패할 때
-     * @author 정시원
-     */
-    public void sendAcceptErrandFcmToSender(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
-        FcmMessage.FcmRequest request = makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.승인);
-
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
-    }
-
-    //TODO 심부름 거절에 대한 push알람 보내는 메서드 생성
-
     /**
      * push알람을 보내기 위헤 사용되는 {@link FcmMessage.FcmRequest}객체를 만든다.
+     *
      * @param fcmSourceDto push알람의 생성에 기본적인 정보를 가지고 있는 DTO
      * @param senderOfPush 해당 push알람을 보내는 회원의 username
      * @param errandAction 심부름에서 하려는 기능
-     * @return fcmPush알람의 메시지를 담고 있는 {@link FcmMessage.FcmRequest}객체
-     * @author 정시원
+     * @return fcmPush알람의 메시지를 담고 있는 {@link FcmMessage.FcmRequest}
+     * @author 정시원, 전지환
      */
-    private FcmMessage.FcmRequest makeErrandFcmMessage(FcmSourceDto fcmSourceDto, String senderOfPush, FcmActionSelector.ErrandAction errandAction){
+    public FcmMessage.FcmRequest makeErrandFcmMessage(FcmSourceDto fcmSourceDto, String senderOfPush, FcmActionSelector.ErrandAction errandAction){
         return FcmMessage.FcmRequest.builder()
                 .title("누군가 " + fcmSourceDto.getFcmPurposeType() + "을(를) " + errandAction + " 했어요!")
                 .body(senderOfPush + "님이 " + errandAction+"한 "+fcmSourceDto.getFcmPurposeType()+"을 확인해보세요!")
                 .build();
-    }
-
-    /**
-     * 받는사람, fcmToken을 찾아주는 메소드
-     * @param recipient
-     * @return recipientFcmToken
-     */
-    private String findRecipientFcmToken(String recipient){
-        return memberRepository.findByUsername(recipient).getFcmToken();
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
@@ -96,7 +96,7 @@ class ErrandServiceImplTest {
                 .username("@kim")
                 .password("1234")
                 .phoneNumber("01023212312")
-                .fcmToken(jihwanFcmToken)
+                .fcmToken(testingFcmToken)
                 .build();
 
         log.info("========= When 받는사람 회원 저장 ==========");

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
@@ -11,6 +11,7 @@ import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
 import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
 import com.server.EZY.notification.service.FirebaseMessagingService;
 import com.server.EZY.util.CurrentUserUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@Slf4j
 class ErrandServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -78,7 +80,7 @@ class ErrandServiceImplTest {
 
     @Test @DisplayName("심부름이 잘 저장되나요?")
     void 심부름_저장_조지기() throws Exception {
-        //Given
+        log.info("==========Given 심부름 세팅==========");
         ErrandSetDto errandSetDto = ErrandSetDto.builder()
                 .location("수완스타벅스")
                 .period(new Period(
@@ -89,16 +91,17 @@ class ErrandServiceImplTest {
                 .recipient("@kim")
                 .build();
 
-        // 받을사람 유저 저장
+        log.info("===========Given 받는사람 회원 세팅============");
         MemberEntity kimEntity = MemberEntity.builder()
                 .username("@kim")
                 .password("1234")
                 .phoneNumber("01023212312")
-                .fcmToken(testingFcmToken)
+                .fcmToken(jihwanFcmToken)
                 .build();
 
-        //When
+        log.info("========= When 받는사람 회원 저장 ==========");
         MemberEntity kimEntitySaved = memberRepository.save(kimEntity);
+        log.info("========= When 심부름 저장 ==========");
         ErrandEntity errandEntity = errandService.sendErrand(errandSetDto);
 
         //Then


### PR DESCRIPTION
## 개선했어요!
1. FcmMaker 클래스에서 maker 메소드와 send 메소드가 공존하였음 -> FcmActiveSender 클래스를 만들어 send 피쳐를 따로 관리 함.
2. '을(를)'이 있었던 문구에서 '을'로 생략부호'()'를 삭제함. 
     이유는 해당 메소드의 목적이 심부름으로 분명하기 때문에 '를' 이라는 목적격 조사가 필요하지 않음.