### PR TITLE
ADD AccessDenied, Authentication Entry Point

### DIFF
--- a/src/main/java/com/server/EZY/security/SecurityConfig.java
+++ b/src/main/java/com/server/EZY/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.server.EZY.security;
 
 import com.server.EZY.security.exception_hendler.FilterExceptionHandlerFilter;
 import com.server.EZY.security.exception_hendler.FilterExceptionHandlerFilterConfig;
+import com.server.EZY.security.handler.CustomAccessDeniedHandler;
+import com.server.EZY.security.handler.CustomAuthenticationEntryPointHandler;
 import com.server.EZY.security.jwt.JwtTokenFilterConfigurer;
 import com.server.EZY.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         // Disable CSRF (cross site request forgery)
-        http.csrf().disable();
+        http
+                .cors().and()
+                .csrf().disable() // rest api이므로 기본설정 사용안함, 기본 설정은 비인증시 로그인 폼으로 리다이렉트
+                .httpBasic().disable(); //rest api, csrf보안이 필요없다.
 
         // No session will be created or used by spring security
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -47,7 +52,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
                 /* 이렇게 권한에 따라 url접속을 제한할 수 있다. (테스트 완료)
                 .antMatchers("/v1/member/test").hasRole("CLIENT")
-                .antMatchers("/v1/admin/test").hasRole("ADMIN")
+                .antMatchers("/v1/admin/**").hasRole("ADMIN")
                 */
 
                 .antMatchers("/v1/errand/**").permitAll() //개발 편의상 permitAll 처리 해 두었음
@@ -60,14 +65,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated();
 
         // If a user try to access a resource without having enough permissions
-        http.exceptionHandling().accessDeniedPage("/login");
+        http.exceptionHandling()
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .authenticationEntryPoint(new CustomAuthenticationEntryPointHandler());
 
         // Apply JWT
         http.apply(new JwtTokenFilterConfigurer(jwtTokenProvider));
         http.apply(new FilterExceptionHandlerFilterConfig(filterExceptionHandlerFilter));
-
-        // Optional, if you want to test the API from a browser
-        // http.httpBasic();
     }
 
     @Override

--- a/src/main/java/com/server/EZY/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/server/EZY/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.server.EZY.security.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException exception) throws IOException, ServletException {
+        log.debug("=== AccessDenied ===");
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/server/EZY/security/handler/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/server/EZY/security/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,2 +1,22 @@
-package com.server.EZY.security.handler;public class CustomAuthenticationEntryPointHandler {
+package com.server.EZY.security.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.debug("=== AuthenticationEntryPoint ===");
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
 }

--- a/src/main/java/com/server/EZY/security/handler/CustomAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/server/EZY/security/handler/CustomAuthenticationEntryPointHandler.java
@@ -1,0 +1,2 @@
+package com.server.EZY.security.handler;public class CustomAuthenticationEntryPointHandler {
+}


### PR DESCRIPTION
### 제가 한 일이에요 !
* security 설정 보완
* accessDenied 추가
* authenticationEntryPoint 추가

> accessDenied 권한이 없거나 잘못된 권한으로 요청했을 때
authenticationEntryPoint 인증실패 또는 인증 헤더가 비어있을 때

### 테스트 컨트롤러를 만들어 swagger에서 테스트한 결과 (테스트 컨트롤러는 테스트하고 삭제)

* 인증 header가 비어있을 때 (accessToken 누락)
![스크린샷 2021-10-20 오전 8 42 19](https://user-images.githubusercontent.com/69895394/138008114-8c3976b5-28a0-4e38-a7c6-6b8f278bca4f.png)

* 잘못된 권한, 또는 권한이 없는 상태에서 요청했을 때
![스크린샷 2021-10-20 오전 8 41 36](https://user-images.githubusercontent.com/69895394/138008117-9a6c696d-399d-432f-b182-9efed776cdc4.png)