### PR TITLE
심부름 수락/거절 NPE해결

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandStatusEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandStatusEntity.java
@@ -1,10 +1,7 @@
 package com.server.EZY.model.plan.errand;
 
 import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -18,20 +15,25 @@ import javax.persistence.*;
 @Entity @Table(name = "errand_status")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(onlyExplicitlyIncluded = true) // @ToString.Include 를 명시한 필드만 toString에 포함합니다.
 public class ErrandStatusEntity {
 
     @Id @Column(name = "errand_status_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ToString.Include
     private Long errandStatusIdx;
 
     @Column(name = "sender_id")
+    @ToString.Include
     private Long senderIdx;
 
     @Column(name = "recipient_id")
+    @ToString.Include
     private Long recipientIdx;
 
     @Column(name = "response_status")
     @Enumerated(EnumType.STRING)
+    @ToString.Include
     private ErrandResponseStatus errandResponseStatus;
 
     public void updateErrandResponseStatus(ErrandResponseStatus errandResponseStatus){

--- a/src/main/java/com/server/EZY/model/plan/errand/repository/errand/ErrandCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/repository/errand/ErrandCustomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.server.EZY.model.plan.errand.repository.errand;
 
-import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPQLQueryFactory;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import java.util.Optional;
 
 import static com.server.EZY.model.plan.errand.QErrandEntity.errandEntity;
+import static com.server.EZY.model.plan.errand.QErrandStatusEntity.errandStatusEntity;
 
 @RequiredArgsConstructor
 public class ErrandCustomRepositoryImpl implements ErrandCustomRepository {
@@ -21,11 +21,11 @@ public class ErrandCustomRepositoryImpl implements ErrandCustomRepository {
      */
     @Override
     public Optional<ErrandEntity> findWithErrandStatusByErrandIdx(long errandIdx) {
-        Tuple errandEntityTuple = queryFactory
-                .select(errandEntity, errandEntity.errandStatusEntity)
+        ErrandEntity errand = (ErrandEntity) queryFactory
                 .from(errandEntity)
-                .where(errandEntity.planIdx.eq(errandIdx))
+                .join(errandEntity.errandStatusEntity, errandStatusEntity)
+                .fetchJoin()
                 .fetchOne();
-        return Optional.ofNullable(errandEntityTuple.get(errandEntity));
+        return Optional.ofNullable(errand);
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
@@ -17,9 +17,7 @@ import com.server.EZY.util.CurrentUserUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -149,12 +147,11 @@ public class ErrandAcceptRefuseTest {
         log.info("========= Given =========");
         // 발신자, 수신자 생성
         MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
-        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+        makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
         MemberEntity otherMember = makeMember("@otherMember", "fcmToken");
 
         // 발신자가 심부름 보냄
         ErrandEntity senderErrandEntity = sendErrand(sender);
-        ErrandStatusEntity senderErrandStatusEntity = senderErrandEntity.getErrandStatusEntity();
         long errandIdx = senderErrandEntity.getPlanIdx();
 
         log.info("========= When, Then =========");
@@ -193,12 +190,11 @@ public class ErrandAcceptRefuseTest {
         log.info("========= Given =========");
         // 발신자, 수신자 생성
         MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
-        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+        makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
         MemberEntity otherMember = makeMember("@otherMember", "fcmToken");
 
         // 발신자가 심부름 보냄
         ErrandEntity senderErrandEntity = sendErrand(sender);
-        ErrandStatusEntity senderErrandStatusEntity = senderErrandEntity.getErrandStatusEntity();
         long errandIdx = senderErrandEntity.getPlanIdx();
 
         log.info("========= When, Then =========");

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
@@ -1,5 +1,6 @@
 package com.server.EZY.model.plan.errand.service;
 
+import com.server.EZY.exception.plan.exception.PlanNotFoundException;
 import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.member.dto.MemberDto;
 import com.server.EZY.model.member.enum_type.Role;
@@ -127,6 +128,20 @@ public class ErrandAcceptRefuseTest {
         assertEquals(ErrandResponseStatus.ACCEPT, recipientErrandStatusEntity.getErrandResponseStatus());
     }
 
+    @Test @DisplayName("심부름 수락시 해당 심부름이 존재하지 않는다면?")
+    void 심부름_수락_존재하지않음() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+        signInMember(recipient);
+        long errandIdx = 999999L;
+
+        log.info("========= When, Than =========");
+        assertThrows(PlanNotFoundException.class,
+                () -> errandService.acceptErrand(errandIdx)
+        );
+    }
+
     @Test @DisplayName("심부름 거절 검증")
     void 심부름_거절_검증() throws Exception {
         log.info("========= Given =========");
@@ -148,5 +163,19 @@ public class ErrandAcceptRefuseTest {
         log.info("========= Then =========");
         assertFalse(errandRepository.existsById(errandIdx));
         assertFalse(errandStatusRepository.existsById(errandStatusIdx));
+    }
+
+    @Test @DisplayName("심부름 거절시 해당 심부름이 존재하지 않는다면?")
+    void 심부름_거절_존재하지않음() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+        signInMember(recipient);
+        long errandIdx = 999999L;
+
+        log.info("========= When, Than =========");
+        assertThrows(PlanNotFoundException.class,
+                () -> errandService.refuseErrand(errandIdx)
+        );
     }
 }


### PR DESCRIPTION
### 한 일
#### 1. `ErrandCustomRepositoryImpl.findWithErrandStatusByErrandIdx` NPE해결
원인은 `Tuple.get(errandEntity)`를 해버리면 만약 `errandEntity`가 null일 때 NPE이 발생합니다.
그래서 fetch join을 통해 `ErrandEntity`와 `ErrandStatusEntity`를 select해 `ErrandEntity`로 반환합니다.

#### 2. 심부름 수락/거절 service로직에 대한 모든 테스트 코드 작성
현재 ErrandService는 테스트 커버리지 100%를 달성했습니다.
![image](https://user-images.githubusercontent.com/62932968/138017287-8eb670d0-6b49-45be-b505-874ca8932595.png)

### 앞으로 진행할 일
- `ErrandStatusEntity`를 `ErandDetailEntity`로 이름 변경

### 코드리뷰 원해요
- querydsl에 대한 query튜닝관련 피드백
- 네이밍 컨벤션에 대한 피드백