### PR TITLE
심부름 읽음 기능 제거

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandDetailEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandDetailEntity.java
@@ -1,6 +1,6 @@
 package com.server.EZY.model.plan.errand;
 
-import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandStatus;
 import lombok.*;
 
 import javax.persistence.*;
@@ -34,22 +34,22 @@ public class ErrandDetailEntity {
     @Column(name = "response_status")
     @Enumerated(EnumType.STRING)
     @ToString.Include
-    private ErrandResponseStatus errandResponseStatus;
+    private ErrandStatus errandStatus;
 
-    public void updateErrandResponseStatus(ErrandResponseStatus errandResponseStatus){
-        this.errandResponseStatus = errandResponseStatus;
+    public void updateErrandStatus(ErrandStatus errandStatus){
+        this.errandStatus = errandStatus;
     }
     /**
      * 심부름의 상태를 추가하는 생성자
      * @param senderIdx 발신자의 MemberIdx
      * @param recipientIdx 수신자의 MemberIdx
-     * @param errandResponseStatus 심부름의 상태
+     * @param errandStatus 심부름의 상태
      * @author 정시원
      */
     @Builder
-    public ErrandDetailEntity(Long senderIdx, Long recipientIdx, ErrandResponseStatus errandResponseStatus){
+    public ErrandDetailEntity(Long senderIdx, Long recipientIdx, ErrandStatus errandStatus){
         this.senderIdx = senderIdx;
         this.recipientIdx = recipientIdx;
-        this.errandResponseStatus = errandResponseStatus;
+        this.errandStatus = errandStatus;
     }
 }

--- a/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
@@ -20,17 +20,6 @@ public class ErrandStatusCycleController {
     private final ErrandService errandService;
 
     /**
-     * 심부름을 받은이가 심부름을 확인(읽음)여부 Controller
-     * @param errandIdx
-     * @return
-     * @author 배태현
-     */
-    @GetMapping("/check/{errandIdx}")
-    public CommonResult readThisSchedule(@PathVariable("errandIdx") Long errandIdx) {
-        return responseService.getSuccessResult();
-    }
-
-    /**
      * 심부름 수락 Controller
      *
      * @param errandIdx 수락할 심부름의 인덱스(planIdx)

--- a/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
@@ -1,5 +1,0 @@
-package com.server.EZY.model.plan.errand.enum_type;
-
-public enum ErrandResponseStatus {
-    NONE, REJECT, ACCEPT, CANCEL, COMPLETION, GIVE_UP
-}

--- a/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandResponseStatus.java
@@ -1,5 +1,5 @@
 package com.server.EZY.model.plan.errand.enum_type;
 
 public enum ErrandResponseStatus {
-    CANCEL, ACCEPT, READ, NOT_READ
+    NONE, REJECT, ACCEPT, CANCEL, COMPLETION, GIVE_UP
 }

--- a/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandStatus.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/enum_type/ErrandStatus.java
@@ -1,0 +1,12 @@
+package com.server.EZY.model.plan.errand.enum_type;
+
+/**
+ * 심부름의 상태를 나타냅니다.
+ *
+ * @author 정시원
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+public enum ErrandStatus {
+    NONE, ACCEPT, REJECT, CANCEL, COMPLETION, GIVE_UP
+}

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -9,7 +9,7 @@ import com.server.EZY.model.plan.enum_type.PlanType;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import com.server.EZY.model.plan.errand.ErrandDetailEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
-import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandStatus;
 import com.server.EZY.model.plan.errand.repository.errand.ErrandRepository;
 import com.server.EZY.model.plan.errand.repository.errand_status.ErrandStatusRepository;
 import com.server.EZY.notification.dto.FcmSourceDto;
@@ -57,7 +57,7 @@ public class ErrandServiceImpl implements ErrandService{
         ErrandDetailEntity errandDetails = ErrandDetailEntity.builder()
                 .senderIdx(sender.getMemberIdx())
                 .recipientIdx(recipient.getMemberIdx())
-                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
+                .errandStatus(ErrandStatus.NONE)
                 .build();
 
         /**
@@ -100,7 +100,7 @@ public class ErrandServiceImpl implements ErrandService{
         ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
         MemberEntity currentMember = currentUserUtil.getCurrentUser();
 
-        senderErrandDetailEntity.updateErrandResponseStatus(ErrandResponseStatus.ACCEPT);
+        senderErrandDetailEntity.updateErrandStatus(ErrandStatus.ACCEPT);
         checkRecipientByErrand(senderErrandDetailEntity, currentMember, InvalidAccessException::new);
 
         ErrandEntity recipientErrand = errandRepository.save(senderErrandEntity.cloneToMemberEntity(currentMember));

--- a/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
@@ -5,7 +5,7 @@ import com.server.EZY.model.member.enum_type.Role;
 import com.server.EZY.model.member.repository.MemberRepository;
 import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
-import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandStatus;
 import com.server.EZY.model.plan.errand.repository.errand.ErrandRepository;
 import com.server.EZY.model.plan.errand.repository.errand_status.ErrandStatusRepository;
 import com.server.EZY.testConfig.QueryDslTestConfig;
@@ -62,7 +62,7 @@ class ErrandTest {
          * errandStatus를 만들어 시원과 지환의 각각생성된 Errand테이블과 연관관계를 맻고 저장한다.
          */
         ErrandDetailEntity errandDetailEntity = ErrandDetailEntity.builder()
-                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
+                .errandStatus(ErrandStatus.NONE)
                 .senderIdx(memberSiwon.getMemberIdx())
                 .recipientIdx(memberJihwan.getMemberIdx())
                 .build();
@@ -116,7 +116,7 @@ class ErrandTest {
     void 심부름_삭제_테스트(){
         // Then
         ErrandDetailEntity errandDetailEntity = ErrandDetailEntity.builder()
-                .errandResponseStatus(ErrandResponseStatus.NOT_READ)
+                .errandStatus(ErrandStatus.NONE)
                 .senderIdx(memberSiwon.getMemberIdx())
                 .recipientIdx(memberJihwan.getMemberIdx())
                 .build();

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandAcceptRefuseTest.java
@@ -10,7 +10,7 @@ import com.server.EZY.model.plan.embedded_type.PlanInfo;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import com.server.EZY.model.plan.errand.ErrandDetailEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
-import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandStatus;
 import com.server.EZY.model.plan.errand.repository.errand.ErrandRepository;
 import com.server.EZY.model.plan.errand.repository.errand_status.ErrandStatusRepository;
 import com.server.EZY.util.CurrentUserUtil;
@@ -125,7 +125,7 @@ public class ErrandAcceptRefuseTest {
         assertEquals(senderErrandDetailEntity.getErrandDetailIdx(), recipientErrandDetailEntity.getErrandDetailIdx());
         assertEquals(senderErrandDetailEntity.getSenderIdx(), recipientErrandDetailEntity.getSenderIdx());
         assertEquals(senderErrandDetailEntity.getRecipientIdx(), recipientErrandDetailEntity.getRecipientIdx());
-        assertEquals(ErrandResponseStatus.ACCEPT, recipientErrandDetailEntity.getErrandResponseStatus());
+        assertEquals(ErrandStatus.ACCEPT, recipientErrandDetailEntity.getErrandStatus());
     }
 
     @Test @DisplayName("심부름 수락시 해당 심부름이 존재하지 않을 떄 PlanNotFoundException검증")

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandServiceImplTest.java
@@ -8,7 +8,7 @@ import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
 import com.server.EZY.model.plan.errand.ErrandEntity;
 import com.server.EZY.model.plan.errand.dto.ErrandSetDto;
-import com.server.EZY.model.plan.errand.enum_type.ErrandResponseStatus;
+import com.server.EZY.model.plan.errand.enum_type.ErrandStatus;
 import com.server.EZY.notification.service.FirebaseMessagingService;
 import com.server.EZY.util.CurrentUserUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -105,7 +105,7 @@ class ErrandServiceImplTest {
         ErrandEntity errandEntity = errandService.sendErrand(errandSetDto);
 
         //Then
-        assertEquals(ErrandResponseStatus.NOT_READ, errandEntity.getErrandDetailEntity().getErrandResponseStatus());
+        assertEquals(ErrandStatus.NONE, errandEntity.getErrandDetailEntity().getErrandStatus());
         assertEquals(memberRepository.findByUsername("@kim").getMemberIdx(), errandEntity.getErrandDetailEntity().getRecipientIdx());
     }
 }


### PR DESCRIPTION
### 한 일
#### 1. 심부름 읽음/안읽음 기능 제거
기능명세서에 심부름 읽음/안읽음 기능이 제거되어 관련된 코드를 삭제 했습니다.
`ErrandResponseStatus`, `ErrandStatusCycleController` 참고하세요!

#### 2. enum class인 `ErrandResponseStatus` -> `ErrandStatus`로 이름 변경했습니다.