### PR TITLE
Get 요청을 제외한 다른 http method의 요청도 basic error로 핸들링이 될 수 있게 다른 http method mapping 추가

### DIFF
--- a/src/main/java/com/server/EZY/exception/basic_error/BasicErrorHandler.java
+++ b/src/main/java/com/server/EZY/exception/basic_error/BasicErrorHandler.java
@@ -5,7 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
@@ -15,7 +18,10 @@ import static org.springframework.http.HttpStatus.*;
 /**
  * SpringBoot에서 white label error를 handling 하기위한 controller
  * basic error(White label error)가 발생하면 JSON형태의 error메세지를 전달하는 BasicErrorController의 URL로 리다이렉트 된다.
- * @author 정시원
+ *
+ * @author 정시원, 배태현
+ * @version 1.0.0
+ * @since 1.0.0
  */
 @Slf4j
 @Controller
@@ -31,11 +37,13 @@ public class BasicErrorHandler implements ErrorController {
     /**
      * BasicError(WhiteLabel) Error가 발생하면
      * BasicError에 대한 Response객체를 반환하는 CustomErrorController에 정의되어있는 url로 리다이렉트 합니다.
+     *
      * @param request HttpServletRequest
      * @return BasicErrorController에 정의해놓은 url주소
+     * @author 정시원, 배태현
      */
     @GetMapping("/error")
-    public String handleError(HttpServletRequest request)  {
+    public String getHandleError(HttpServletRequest request)  {
 
         final Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
         final int statusCode = Integer.parseInt(status.toString());
@@ -46,6 +54,105 @@ public class BasicErrorHandler implements ErrorController {
                 "http status code : {}\n" +
                 "url : {}\n" +
                 "IP : {}"
+                ,statusCode, request.getRequestURI(), IP
+        );
+
+        if(statusCode == UNAUTHORIZED.value())
+            return BASIC_ERROR_BASE_URL + UNAUTHORIZED_401_CODE_NAME;
+        if(statusCode == FORBIDDEN.value())
+            return BASIC_ERROR_BASE_URL + FORBIDDEN_403_CODE_NAME;
+        if(statusCode == NOT_FOUND.value())
+            return BASIC_ERROR_BASE_URL + NOT_FOUND_404_CODE_NAME;
+
+        throw new CustomException("basic error처리중 알 수 없는 에러가 발생해 error handling을 하지 못했습니다", INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * BasicError(WhiteLabel) Error가 발생하면
+     * BasicError에 대한 Response객체를 반환하는 CustomErrorController에 정의되어있는 url로 리다이렉트 합니다.
+     *
+     * @param request HttpServletRequest
+     * @return BasicErrorController에 정의해놓은 url주소
+     * @author 정시원, 배태현
+     */
+    @PostMapping("/error")
+    public String postHandleError(HttpServletRequest request)  {
+
+        final Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        final int statusCode = Integer.parseInt(status.toString());
+
+        final String IP = request.getRemoteAddr() != null ? request.getRemoteAddr() : request.getHeader("X-FORWARDED-FOR");
+
+        log.info("\n=== Basic Error(WhiteLabel Error) 발생 === \n" +
+                        "http status code : {}\n" +
+                        "url : {}\n" +
+                        "IP : {}"
+                ,statusCode, request.getRequestURI(), IP
+        );
+
+        if(statusCode == UNAUTHORIZED.value())
+            return BASIC_ERROR_BASE_URL + UNAUTHORIZED_401_CODE_NAME;
+        if(statusCode == FORBIDDEN.value())
+            return BASIC_ERROR_BASE_URL + FORBIDDEN_403_CODE_NAME;
+        if(statusCode == NOT_FOUND.value())
+            return BASIC_ERROR_BASE_URL + NOT_FOUND_404_CODE_NAME;
+
+        throw new CustomException("basic error처리중 알 수 없는 에러가 발생해 error handling을 하지 못했습니다", INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * BasicError(WhiteLabel) Error가 발생하면
+     * BasicError에 대한 Response객체를 반환하는 CustomErrorController에 정의되어있는 url로 리다이렉트 합니다.
+     *
+     * @param request HttpServletRequest
+     * @return BasicErrorController에 정의해놓은 url주소
+     * @author 정시원, 배태현
+     */
+    @PutMapping("/error")
+    public String putHandleError(HttpServletRequest request)  {
+
+        final Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        final int statusCode = Integer.parseInt(status.toString());
+
+        final String IP = request.getRemoteAddr() != null ? request.getRemoteAddr() : request.getHeader("X-FORWARDED-FOR");
+
+        log.info("\n=== Basic Error(WhiteLabel Error) 발생 === \n" +
+                        "http status code : {}\n" +
+                        "url : {}\n" +
+                        "IP : {}"
+                ,statusCode, request.getRequestURI(), IP
+        );
+
+        if(statusCode == UNAUTHORIZED.value())
+            return BASIC_ERROR_BASE_URL + UNAUTHORIZED_401_CODE_NAME;
+        if(statusCode == FORBIDDEN.value())
+            return BASIC_ERROR_BASE_URL + FORBIDDEN_403_CODE_NAME;
+        if(statusCode == NOT_FOUND.value())
+            return BASIC_ERROR_BASE_URL + NOT_FOUND_404_CODE_NAME;
+
+        throw new CustomException("basic error처리중 알 수 없는 에러가 발생해 error handling을 하지 못했습니다", INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * BasicError(WhiteLabel) Error가 발생하면
+     * BasicError에 대한 Response객체를 반환하는 CustomErrorController에 정의되어있는 url로 리다이렉트 합니다.
+     *
+     * @param request HttpServletRequest
+     * @return BasicErrorController에 정의해놓은 url주소
+     * @author 정시원, 배태현
+     */
+    @DeleteMapping("/error")
+    public String deleteHandleError(HttpServletRequest request)  {
+
+        final Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        final int statusCode = Integer.parseInt(status.toString());
+
+        final String IP = request.getRemoteAddr() != null ? request.getRemoteAddr() : request.getHeader("X-FORWARDED-FOR");
+
+        log.info("\n=== Basic Error(WhiteLabel Error) 발생 === \n" +
+                        "http status code : {}\n" +
+                        "url : {}\n" +
+                        "IP : {}"
                 ,statusCode, request.getRequestURI(), IP
         );
 

--- a/src/main/java/com/server/EZY/exception/basic_error/controller/BasicErrorController.java
+++ b/src/main/java/com/server/EZY/exception/basic_error/controller/BasicErrorController.java
@@ -4,9 +4,7 @@ import com.server.EZY.exception.basic_error.BasicErrorHandler;
 import com.server.EZY.response.result.CommonResult;
 import com.server.EZY.util.ExceptionResponseObjectUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(BasicErrorHandler.BASIC_ERROR_BASE_URL)
@@ -16,17 +14,62 @@ public class BasicErrorController {
     private final ExceptionResponseObjectUtil exceptionResponseObjectUtil;
 
     @GetMapping(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME)
-    public CommonResult unauthorized(){
+    public CommonResult getUnauthorized(){
         return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME);
     }
 
     @GetMapping(BasicErrorHandler.FORBIDDEN_403_CODE_NAME)
-    public CommonResult forbidden(){
+    public CommonResult getForbidden(){
         return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.FORBIDDEN_403_CODE_NAME);
     }
 
     @GetMapping(BasicErrorHandler.NOT_FOUND_404_CODE_NAME)
-    public CommonResult notFound(){
+    public CommonResult getNotFound(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.NOT_FOUND_404_CODE_NAME);
+    }
+
+    @PostMapping(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME)
+    public CommonResult postUnauthorized(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME);
+    }
+
+    @PostMapping(BasicErrorHandler.FORBIDDEN_403_CODE_NAME)
+    public CommonResult postForbidden(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.FORBIDDEN_403_CODE_NAME);
+    }
+
+    @PostMapping(BasicErrorHandler.NOT_FOUND_404_CODE_NAME)
+    public CommonResult postNotFound(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.NOT_FOUND_404_CODE_NAME);
+    }
+
+    @PutMapping(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME)
+    public CommonResult putUnauthorized(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME);
+    }
+
+    @PutMapping(BasicErrorHandler.FORBIDDEN_403_CODE_NAME)
+    public CommonResult putForbidden(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.FORBIDDEN_403_CODE_NAME);
+    }
+
+    @PutMapping(BasicErrorHandler.NOT_FOUND_404_CODE_NAME)
+    public CommonResult putNotFound(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.NOT_FOUND_404_CODE_NAME);
+    }
+
+    @DeleteMapping(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME)
+    public CommonResult deleteUnauthorized(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.UNAUTHORIZED_401_CODE_NAME);
+    }
+
+    @DeleteMapping(BasicErrorHandler.FORBIDDEN_403_CODE_NAME)
+    public CommonResult deleteForbidden(){
+        return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.FORBIDDEN_403_CODE_NAME);
+    }
+
+    @DeleteMapping(BasicErrorHandler.NOT_FOUND_404_CODE_NAME)
+    public CommonResult deleteNotFound(){
         return exceptionResponseObjectUtil.getExceptionResponseObj(BasicErrorHandler.NOT_FOUND_404_CODE_NAME);
     }
 }


### PR DESCRIPTION
### 제가 한 일이에요 !
* Get 요청을 제외한 다른 http method의 요청도 basic error로 핸들링이 될 수 있게 다른 http method mapping 추가

![스크린샷 2021-10-25 오전 9 04 05](https://user-images.githubusercontent.com/69895394/138618710-cfaafca6-fb36-497b-bcfa-3de9dcd15153.png)

![스크린샷 2021-10-25 오전 9 04 10](https://user-images.githubusercontent.com/69895394/138618708-9565afa6-d169-401a-b4f8-58674f9a4ac4.png)

<img width="807" alt="스크린샷 2021-10-25 오전 9 04 34" src="https://user-images.githubusercontent.com/69895394/138618705-be5ef482-a490-429a-af19-9ad1da707e6e.png">

<img width="1922" alt="스크린샷 2021-10-25 오전 9 04 16" src="https://user-images.githubusercontent.com/69895394/138618707-86d10348-6c82-4935-bf6d-6df38b4287e3.png">

> 위 처럼 GetMapping 만 error handling이 되고 다른 mapping들은 알 수 없는 에러로 핸들링 되는 것을 확인하였습니다.
요청 controller의 http method와 에러 핸들링 mapping method는 통일되어야 한다. 
저와 같은 에러는 아니지만 구글링을 하다 이 참고자료의 답변을 보고 
왜 에러 핸들링이 안되는지 알 것 같아 error handler에 다른 method의 mapping도 추가하였더니 error 핸들링에 성공하였습니다. 
[[참고자료]](https://stackoverflow.com/questions/49125075/spring-security-login-error-request-method-post-not-supported)

### 추가해준 결과
![스크린샷 2021-10-25 오전 9 19 27](https://user-images.githubusercontent.com/69895394/138618704-37861757-fbc6-4559-b28f-6bb09dc48694.png)

> 일단 임시로 이렇게 매핑 코드를 복붙 해놓고 나중에 @siwony 님과 함께 코드를 다듬기로 하였습니다 ...