### PR TITLE
심부름 실패 

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
@@ -58,22 +58,28 @@ public class ErrandStatusCycleController {
     /**
      * 심부름 완료 Controller
      * @param errandIdx
-     * @return
-     * @author 배태현
+     * @throws InvalidAccessException 해당 심부름에 잘못된 접근을 할 경우
+     * @throws PlanNotFoundException  해당 심부름이 존재하지 않을 때
+     * @return SuccessResult - 심부름 성공 성공시
+     * @author 배태현, 정시원
      */
     @PutMapping("/complete/{errandIdx}")
-    public CommonResult completeErrand(@PathVariable("errandIdx") Long errandIdx) {
+    public CommonResult completeErrand(@PathVariable("errandIdx") Long errandIdx) throws FirebaseMessagingException {
+        errandService.completionErrand(errandIdx);
         return responseService.getSuccessResult();
     }
 
     /**
-     * 심부름 실패 Controller
+     * 심부름 포기 Controller
      * @param errandIdx
-     * @return
-     * @author 배태현
+     * @throws InvalidAccessException 해당 심부름에 잘못된 접근을 할 경우
+     * @throws PlanNotFoundException  해당 심부름이 존재하지 않을 때
+     * @return SuccessResult - 심부름 포기 성공시
+     * @author 정시원
      */
-    @PutMapping("/fail/{errandIdx}")
-    public CommonResult failErrand(@PathVariable("errandIdx") Long errandIdx) {
+    @PutMapping("/give-up")
+    public CommonResult giveUpErrand(@PathVariable("errandIdx") Long errandIdx) {
         return responseService.getSuccessResult();
     }
+
 }

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandService.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandService.java
@@ -47,4 +47,13 @@ public interface ErrandService {
      * @author 정시원
      */
     void completionErrand(long errandIdx) throws FirebaseMessagingException;
+
+    /**
+     * 심부름을 수신자가 포기한다.
+     *
+     * @param errandIdx 포기할 심부름 Idx
+     * @throws FirebaseMessagingException push알람이 실패할 때
+     * @author 정시원
+     */
+    void giveUpErrand(long errandIdx) throws FirebaseMessagingException;
 }

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -179,6 +179,35 @@ public class ErrandServiceImpl implements ErrandService{
     }
 
     /**
+     * 심부름을 수신자가 포기한다.
+     *
+     * @param errandIdx 포기할 심부름 Idx
+     * @throws FirebaseMessagingException push알람이 실패할 때
+     * @author 정시원
+     */
+    @Override
+    public void giveUpErrand(long errandIdx) throws FirebaseMessagingException {
+        ErrandEntity errandEntity = errandRepository.findWithErrandStatusByErrandIdx(errandIdx)
+                .orElseThrow(
+                        () -> new PlanNotFoundException(PlanType.심부름)
+                );
+        ErrandDetailEntity errandDetailEntity = errandEntity.getErrandDetailEntity();
+        MemberEntity sender = memberRepository.getById(errandDetailEntity.getSenderIdx());
+        MemberEntity recipient = currentUserUtil.getCurrentUser();
+
+        errandDetailEntity.updateErrandStatus(ErrandStatus.GIVE_UP);
+
+        FcmSourceDto fcmSourceDto = FcmSourceDto.builder()
+                .sender(sender.getUsername())
+                .recipient(recipient.getUsername())
+                .fcmPurposeType(FcmPurposeType.심부름)
+                .fcmRole(FcmRole.받는사람)
+                .build();
+
+        //TODO 해당 심부름 포기 push알람 전송
+    }
+
+    /**
      * 이 심부름의 발신자가 아닌지 확인하고, Supplier로 넘겨준 Exception을 던진다.
      *
      * @param errandDetailEntity - 해당 심부름의 발신자의 정보를 가지고 있는 ErrandDetailEntity

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -195,6 +195,8 @@ public class ErrandServiceImpl implements ErrandService{
         MemberEntity sender = memberRepository.getById(errandDetailEntity.getSenderIdx());
         MemberEntity recipient = currentUserUtil.getCurrentUser();
 
+        checkRecipientByErrand(errandDetailEntity, recipient, InvalidAccessException::new);
+
         errandDetailEntity.updateErrandStatus(ErrandStatus.GIVE_UP);
 
         FcmSourceDto fcmSourceDto = FcmSourceDto.builder()
@@ -204,7 +206,7 @@ public class ErrandServiceImpl implements ErrandService{
                 .fcmRole(FcmRole.받는사람)
                 .build();
 
-        //TODO 해당 심부름 포기 push알람 전송
+        fcmActiveSender.sendGiveUpErrandFcmToSender(fcmSourceDto);
     }
 
     /**

--- a/src/main/java/com/server/EZY/notification/enum_type/FcmActionSelector.java
+++ b/src/main/java/com/server/EZY/notification/enum_type/FcmActionSelector.java
@@ -2,6 +2,6 @@ package com.server.EZY.notification.enum_type;
 
 public class FcmActionSelector {
     public enum ErrandAction {
-        요청, 거절, 승인, 완료
+        요청, 거절, 승인, 완료, 포기
     }
 }

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -27,7 +27,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getSender(), FcmActionSelector.ErrandAction.요청);
         // 실제로 push를 전송하는 구간
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getRecipient()));
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
     }
 
     /**
@@ -41,7 +41,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.승인);
         // 실제로 push를 전송하는 구간
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**
@@ -55,7 +55,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.거절);
 
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**
@@ -68,7 +68,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandConfirmFcmMessageToRecipient(fcmSourceDto, FcmActionSelector.ErrandAction.완료);
 
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getRecipient()));
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
     }
 
     /**
@@ -81,7 +81,7 @@ public class FcmActiveSender {
     public void sendGiveUpErrandFcmToSender(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException{
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.포기);
-        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**
@@ -91,7 +91,7 @@ public class FcmActiveSender {
      * @return recipientFcmToken
      * @author 전지환
      */
-    private String findRecipientFcmToken(String recipient){
+    private String findFcmTokenByUsername(String recipient){
         return memberRepository.findByUsername(recipient).getFcmToken();
     }
 }

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -58,6 +58,12 @@ public class FcmActiveSender {
         firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
     }
 
+    /**
+     * 심부름 완료 정보를 수신자에게 push알람을 보낸다.
+     *
+     * @param fcmSourceDto 해당 push알람이 실패할 때
+     * @throws FirebaseMessagingException 해당 push알람이 실패할 때
+     */
     public void sendCompletionErrandFcmToRecipient(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandConfirmFcmMessageToRecipient(fcmSourceDto, FcmActionSelector.ErrandAction.완료);

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -66,6 +66,19 @@ public class FcmActiveSender {
     }
 
     /**
+     * 심부름 포기 정보를 수신자에게 push알람을 보낸다
+     *
+     * @param fcmSourceDto push알람의 생성에 기본적인 정보를 가지고 있는 DTO
+     * @throws FirebaseMessagingException 해당 push알람이 실패할 때
+     * @author 정시원
+     */
+    public void sendGiveUpErrandFcmToSender(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException{
+        FcmMessage.FcmRequest request =
+                fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.포기);
+        firebaseMessagingService.sendToToken(request, findRecipientFcmToken(fcmSourceDto.getSender()));
+    }
+
+    /**
      * target, fcm target token을 찾아준다.
      *
      * @param recipient

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
@@ -40,11 +40,11 @@ public class ErrandStatusCycleTest {
     @Autowired private ErrandRepository errandRepository;
     @Autowired private ErrandStatusRepository errandStatusRepository;
 
-    // 전지환의 tokenRECIPIENT_FCM_TOKEN
-    private final String RECIPIENT_FCM_TOKEN = "eQb5CygpsUahmPBRDnTc0N:APA91bFaOlt2nZDJKJpO8dZsjS8vSDCZKxZWYBWtNXYUiIiUxLPiGTLcXuyuVTW1uqOxu55Ay9z_1ss-D2uz2xP-C_R2-5yxyV2pqn88zYts4WSxS4pgWgdvFtBAG6nU__dSYH7WW8Qk";
+    // 전지환의 token
+    private final String SENDER_FCM_TOKEN = "eQb5CygpsUahmPBRDnTc0N:APA91bFaOlt2nZDJKJpO8dZsjS8vSDCZKxZWYBWtNXYUiIiUxLPiGTLcXuyuVTW1uqOxu55Ay9z_1ss-D2uz2xP-C_R2-5yxyV2pqn88zYts4WSxS4pgWgdvFtBAG6nU__dSYH7WW8Qk";
 
     // 정시원의 token
-    private final String SENDER_FCM_TOKEN = "cK_nm9tK3EdzgwOQXfjPbU:APA91bE-877ItvJsFelwTb23hntRort6v8fN-yGC8Mq1jzb8JEu3Qzi4oi7zJUKt6zigX02pjcQ84rwOQZjMngTdAkR6IKYygs-ZkGN94SNU6yY2MR8YqGvu2jLoPxQQ_f9pfQ8YdeZZ";
+    private final String RECIPIENT_FCM_TOKEN = "cK_nm9tK3EdzgwOQXfjPbU:APA91bE-877ItvJsFelwTb23hntRort6v8fN-yGC8Mq1jzb8JEu3Qzi4oi7zJUKt6zigX02pjcQ84rwOQZjMngTdAkR6IKYygs-ZkGN94SNU6yY2MR8YqGvu2jLoPxQQ_f9pfQ8YdeZZ";
 
     private final String SENDER_USERNAME = "@sender";
     private final String RECIPIENT_USERNAME = "@recipient";
@@ -240,47 +240,5 @@ public class ErrandStatusCycleTest {
         log.info("========= Then =========");
         assertEquals(senderErrandDetailEntity.getErrandStatus(), ErrandStatus.COMPLETION);
 
-    }
-
-    @Test @DisplayName("심부름 포기 테스트")
-    void 심부름_포기_검증() throws Exception {
-        log.info("========= Given =========");
-        // 발신자, 수신자 생성
-        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
-        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
-
-        // 발신자가 심부름 보냄
-        ErrandEntity senderErrandEntity = sendErrand(sender);
-        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
-        long errandIdx = senderErrandEntity.getPlanIdx();
-        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
-
-        log.info("========= When =========");
-        //로그인 후 sender의 심부름을 포기함
-        signInMember(recipient);
-        errandService.giveUpErrand(errandIdx);
-
-        log.info("========= Then =========");
-        assertEquals(ErrandStatus.GIVE_UP, senderErrandDetailEntity.getErrandStatus());
-    }
-
-    @Test @DisplayName("심부름 포기를 수신자가 아닌 다른사람이 접근한다면? 테스트")
-    void 심부름_InvalidAccessException_검증() throws Exception {
-        log.info("========= Given =========");
-        // 발신자, 수신자 생성
-        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
-        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
-
-        // 발신자가 심부름 보냄
-        ErrandEntity senderErrandEntity = sendErrand(sender);
-        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
-        long errandIdx = senderErrandEntity.getPlanIdx();
-        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
-
-        log.info("========= When, Then =========");
-        signInMember(sender); // 수신자가 아닌 발신자가 해당 메서드를 실행할 때
-        assertThrows(InvalidAccessException.class,
-                () -> errandService.giveUpErrand(errandIdx)
-        );
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
@@ -239,6 +239,47 @@ public class ErrandStatusCycleTest {
 
         log.info("========= Then =========");
         assertEquals(senderErrandDetailEntity.getErrandStatus(), ErrandStatus.COMPLETION);
+    }
 
+    @Test @DisplayName("심부름 포기 테스트")
+    void 심부름_포기_검증() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+
+        // 발신자가 심부름 보냄
+        ErrandEntity senderErrandEntity = sendErrand(sender);
+        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
+        long errandIdx = senderErrandEntity.getPlanIdx();
+        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
+
+        log.info("========= When =========");
+        //로그인 후 sender의 심부름을 포기함
+        signInMember(recipient);
+        errandService.giveUpErrand(errandIdx);
+
+        log.info("========= Then =========");
+        assertEquals(ErrandStatus.GIVE_UP, senderErrandDetailEntity.getErrandStatus());
+    }
+
+    @Test @DisplayName("심부름 포기를 수신자가 아닌 다른사람이 접근한다면? 테스트")
+    void 심부름_InvalidAccessException_검증() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+
+        // 발신자가 심부름 보냄
+        ErrandEntity senderErrandEntity = sendErrand(sender);
+        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
+        long errandIdx = senderErrandEntity.getPlanIdx();
+        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
+
+        log.info("========= When, Then =========");
+        signInMember(sender); // 수신자가 아닌 발신자가 해당 메서드를 실행할 때
+        assertThrows(InvalidAccessException.class,
+                () -> errandService.giveUpErrand(errandIdx)
+        );
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
@@ -40,11 +40,11 @@ public class ErrandStatusCycleTest {
     @Autowired private ErrandRepository errandRepository;
     @Autowired private ErrandStatusRepository errandStatusRepository;
 
-    // 전지환의 token
-    private final String SENDER_FCM_TOKEN = "eQb5CygpsUahmPBRDnTc0N:APA91bFaOlt2nZDJKJpO8dZsjS8vSDCZKxZWYBWtNXYUiIiUxLPiGTLcXuyuVTW1uqOxu55Ay9z_1ss-D2uz2xP-C_R2-5yxyV2pqn88zYts4WSxS4pgWgdvFtBAG6nU__dSYH7WW8Qk";
+    // 전지환의 tokenRECIPIENT_FCM_TOKEN
+    private final String RECIPIENT_FCM_TOKEN = "eQb5CygpsUahmPBRDnTc0N:APA91bFaOlt2nZDJKJpO8dZsjS8vSDCZKxZWYBWtNXYUiIiUxLPiGTLcXuyuVTW1uqOxu55Ay9z_1ss-D2uz2xP-C_R2-5yxyV2pqn88zYts4WSxS4pgWgdvFtBAG6nU__dSYH7WW8Qk";
 
     // 정시원의 token
-    private final String RECIPIENT_FCM_TOKEN = "cK_nm9tK3EdzgwOQXfjPbU:APA91bE-877ItvJsFelwTb23hntRort6v8fN-yGC8Mq1jzb8JEu3Qzi4oi7zJUKt6zigX02pjcQ84rwOQZjMngTdAkR6IKYygs-ZkGN94SNU6yY2MR8YqGvu2jLoPxQQ_f9pfQ8YdeZZ";
+    private final String SENDER_FCM_TOKEN = "cK_nm9tK3EdzgwOQXfjPbU:APA91bE-877ItvJsFelwTb23hntRort6v8fN-yGC8Mq1jzb8JEu3Qzi4oi7zJUKt6zigX02pjcQ84rwOQZjMngTdAkR6IKYygs-ZkGN94SNU6yY2MR8YqGvu2jLoPxQQ_f9pfQ8YdeZZ";
 
     private final String SENDER_USERNAME = "@sender";
     private final String RECIPIENT_USERNAME = "@recipient";
@@ -240,5 +240,47 @@ public class ErrandStatusCycleTest {
         log.info("========= Then =========");
         assertEquals(senderErrandDetailEntity.getErrandStatus(), ErrandStatus.COMPLETION);
 
+    }
+
+    @Test @DisplayName("심부름 포기 테스트")
+    void 심부름_포기_검증() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+
+        // 발신자가 심부름 보냄
+        ErrandEntity senderErrandEntity = sendErrand(sender);
+        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
+        long errandIdx = senderErrandEntity.getPlanIdx();
+        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
+
+        log.info("========= When =========");
+        //로그인 후 sender의 심부름을 포기함
+        signInMember(recipient);
+        errandService.giveUpErrand(errandIdx);
+
+        log.info("========= Then =========");
+        assertEquals(ErrandStatus.GIVE_UP, senderErrandDetailEntity.getErrandStatus());
+    }
+
+    @Test @DisplayName("심부름 포기를 수신자가 아닌 다른사람이 접근한다면? 테스트")
+    void 심부름_InvalidAccessException_검증() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+
+        // 발신자가 심부름 보냄
+        ErrandEntity senderErrandEntity = sendErrand(sender);
+        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
+        long errandIdx = senderErrandEntity.getPlanIdx();
+        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
+
+        log.info("========= When, Then =========");
+        signInMember(sender); // 수신자가 아닌 발신자가 해당 메서드를 실행할 때
+        assertThrows(InvalidAccessException.class,
+                () -> errandService.giveUpErrand(errandIdx)
+        );
     }
 }


### PR DESCRIPTION
### 한 일
#### 1. 심부름 실패 기능추가
제가 생각한 로직flow는 다음과 같아요
> 수신자가 심부름 포기 -> 발신자에게 수신자가 심부름을 포기한 정보를 push로 알려줌 -> 심부름 종료

#### 2. etc
- 매서드명 변경 `FcmActiveSender.findRecipientFcmToken` &rarr; `FcmActiveSender.findFcmTokenByUsername`
- Controller와 주석 누락된 부분 추가

### 코드리뷰 원해요
- 명명규칙에 대한 피드백
- 더 나은 로직에 대한 피드백