### PR TITLE
심부름 실패 기능 추가

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
@@ -77,8 +77,9 @@ public class ErrandStatusCycleController {
      * @return SuccessResult - 심부름 포기 성공시
      * @author 정시원
      */
-    @PutMapping("/give-up")
-    public CommonResult giveUpErrand(@PathVariable("errandIdx") Long errandIdx) {
+    @PutMapping("/give-up/{errandIdx}")
+    public CommonResult giveUpErrand(@PathVariable("errandIdx") Long errandIdx) throws FirebaseMessagingException {
+        errandService.giveUpErrand(errandIdx);
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/controller/ErrandStatusCycleController.java
@@ -69,6 +69,21 @@ public class ErrandStatusCycleController {
         return responseService.getSuccessResult();
     }
 
+
+    /**
+     * 심부름 실패 Controller
+     * @param errandIdx
+     * @throws InvalidAccessException 해당 심부름에 잘못된 접근을 할 경우
+     * @throws PlanNotFoundException  해당 심부름이 존재하지 않을 때
+     * @return SuccessResult - 심부름 포기 성공시
+     * @author 정시원
+     */
+    @PutMapping("/fail/{errandIdx}")
+    public CommonResult failErrand(@PathVariable("errandIdx") Long errandIdx) throws FirebaseMessagingException {
+        errandService.failErrand(errandIdx);
+        return responseService.getSuccessResult();
+    }
+
     /**
      * 심부름 포기 Controller
      * @param errandIdx

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandService.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandService.java
@@ -49,6 +49,15 @@ public interface ErrandService {
     void completionErrand(long errandIdx) throws FirebaseMessagingException;
 
     /**
+     * 심부름이 실패한다. <br>
+     * 해당 심부름의 ErrandDetailEntity의 ErrandStauts가 FAIL 으로 변경되고, 수신자에게 실패 push알람이 전송된다.
+     *
+     * @param errandIdx 거절할 errandIdx(planIdx)
+     * @author 정시원
+     */
+    void failErrand(long errandIdx) throws FirebaseMessagingException;
+
+    /**
      * 심부름을 수신자가 포기한다.
      *
      * @param errandIdx 포기할 심부름 Idx

--- a/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/service/ErrandServiceImpl.java
@@ -207,7 +207,7 @@ public class ErrandServiceImpl implements ErrandService{
                 .fcmRole(FcmRole.받는사람)
                 .build();
 
-        // TODO push알람 추가
+        fcmActiveSender.sendFailErrandFcmToRecipient(fcmSourceDto);
     }
 
     /**

--- a/src/main/java/com/server/EZY/notification/enum_type/FcmActionSelector.java
+++ b/src/main/java/com/server/EZY/notification/enum_type/FcmActionSelector.java
@@ -2,6 +2,6 @@ package com.server.EZY.notification.enum_type;
 
 public class FcmActionSelector {
     public enum ErrandAction {
-        요청, 거절, 승인, 완료, 포기
+        요청, 거절, 승인, 완료, 포기, 실패
     }
 }

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -72,6 +72,19 @@ public class FcmActiveSender {
     }
 
     /**
+     * 심부름 실패 정보를 수신자에게 push알람을 보낸다.
+     *
+     * @param fcmSourceDto 해당 push알람이 실패할 때
+     * @throws FirebaseMessagingException 해당 push알람이 실패할 때
+     */
+    public void sendFailErrandFcmToRecipient(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException {
+        FcmMessage.FcmRequest request =
+                fcmMakerService.makeErrandConfirmFcmMessageToRecipient(fcmSourceDto, FcmActionSelector.ErrandAction.실패);
+
+        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
+    }
+
+    /**
      * 심부름 포기 정보를 수신자에게 push알람을 보낸다
      *
      * @param fcmSourceDto push알람의 생성에 기본적인 정보를 가지고 있는 DTO

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
@@ -241,6 +241,28 @@ public class ErrandStatusCycleTest {
         assertEquals(senderErrandDetailEntity.getErrandStatus(), ErrandStatus.COMPLETION);
     }
 
+    @Test @DisplayName("심부름 실패 테스트")
+    void 심부름_실패_검증() throws Exception {
+        log.info("========= Given =========");
+        // 발신자, 수신자 생성
+        MemberEntity sender = makeMember(SENDER_USERNAME, SENDER_FCM_TOKEN);
+        MemberEntity recipient = makeMember(RECIPIENT_USERNAME, RECIPIENT_FCM_TOKEN);
+
+        // 발신자가 심부름 보냄
+        ErrandEntity senderErrandEntity = sendErrand(sender);
+        ErrandDetailEntity senderErrandDetailEntity = senderErrandEntity.getErrandDetailEntity();
+        long errandIdx = senderErrandEntity.getPlanIdx();
+        long errandStatusIdx = senderErrandDetailEntity.getErrandDetailIdx();
+
+        log.info("========= When =========");
+        //로그인 후 sender의 심부름을 수락함
+        signInMember(sender);
+        errandService.failErrand(errandIdx);
+
+        log.info("========= Then =========");
+        assertEquals(senderErrandDetailEntity.getErrandStatus(), ErrandStatus.FAIL);
+    }
+
     @Test @DisplayName("심부름 포기 테스트")
     void 심부름_포기_검증() throws Exception {
         log.info("========= Given =========");


### PR DESCRIPTION
### 한 일
#### 1. 심부름 실패 기능 추가했습니다.
제가 생각한 로직flow는 다음과 같아요
> 발신자가 심부름 상태를 실패로 변경-> 발신자에게 수신자가 심부름을 포기한 정보를 push로 알려줌 -> 심부름 종료

#### 2. ETC...
- 테스트코드 작성
- 심부름 포기 controller 빠진 부분 추가

### 앞으로 할 일
1. 심부름 상태 로직 전부 리펙터링
2. 심부름 테스트 시 push알람을 발송하지 않고 가상으로 테스트 하도록 변경
3. FCM 비동기 처리 및 push알람 실패시 지수 백오프를 이용한 재발송 기능 추가

### 코드리뷰 원해요
- 명명규칙에 대한 피드백
- 더 나은 로직에 대한 피드백