### PR TITLE
Feature/fcm test mode

### DIFF
--- a/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
+++ b/src/main/java/com/server/EZY/config/message/MessageConfiguration.java
@@ -15,6 +15,12 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+/**
+ * i18n를 위한 configuration class
+ * @author 정시원
+ * @since 1.0.0
+ * @version 1.0.0
+ */
 @Configuration
 public class MessageConfiguration implements WebMvcConfigurer {
 
@@ -45,6 +51,7 @@ public class MessageConfiguration implements WebMvcConfigurer {
     /**
      * 로컬 정보를 변경한 interceptor({@link #localeChangeInterceptor} 참고)를 시스템 레지스터리에 저장한다.<br>
      * @param registry Interceptor의 저장 및 엑세스를 제공한다. (Spring에서 주입한다.)
+     * @author 정시원
      */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -56,6 +63,7 @@ public class MessageConfiguration implements WebMvcConfigurer {
      * @param basename 사용자 지정 메시지가 정의되어있는 base 디렉토리 위치를 나타낸다. (i18n/exception)
      * @param encoding 인코딩 정보 (application.yml에 UTF-8로 설정했다.)
      * @return (YamlMessageSource)MessageSource - yml속 메시지를 사용하기 위해 설정한 객체
+     * @author 정시원
      */
     @Bean
     public MessageSource messageSource(

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 import javax.annotation.PostConstruct;
@@ -84,6 +85,16 @@ public class FirebaseMessagingConfig {
                 .createScoped(Arrays.asList(SCOPES));
         googleCredentials.refreshIfExpired();
         return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+    @Bean("isFcmTest") @Profile("test_code")
+    public boolean isFcmTestTrue(){
+        return true;
+    }
+
+    @Bean("isFcmTest") @Profile({"dev", "test", "default"})
+    public boolean isFcmTestFalse(){
+        return false;
     }
 
 }

--- a/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
+++ b/src/main/java/com/server/EZY/notification/config/FirebaseMessagingConfig.java
@@ -4,6 +4,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.server.EZY.notification.FcmMessage;
+import com.server.EZY.notification.service.FirebaseMessagingService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +19,8 @@ import java.util.Arrays;
 /**
  * FCM관련 구성요소를 초기화하는 Config클래스
  * @author 정시원
+ * @version 1.0.0
+ * @since 1.0.0
  */
 @Slf4j
 @Configuration
@@ -87,12 +91,30 @@ public class FirebaseMessagingConfig {
         return googleCredentials.getAccessToken().getTokenValue();
     }
 
-    @Bean("isFcmTest") @Profile("test_code")
+    /**
+     * test_code 프로필로 FCM push 알람을 보낼 때 테스트로 보내기 위한 메서드  <br>
+     * 실제로 push 알람을 보내지 않아도 되는 테스트 코드에서 즉, test_code로 실행될 떄 활성화 된다. <br>
+     * @see FirebaseMessagingService#sendToToken(FcmMessage.FcmRequest, String)
+     * @see #isFcmTestFalse
+     * @return true
+     * @author 정시원
+     */
+    @Profile("test_code")
+    @Bean("isFcmTest")
     public boolean isFcmTestTrue(){
         return true;
     }
 
-    @Bean("isFcmTest") @Profile({"dev", "test", "default"})
+    /**
+     * 실제 운영시 FCM push 알람을 보낼 떄 실제로 보내기 위한 메서드 <br>
+     * dev, test, default 프로필 즉, 테스트 혹은 실제 운영시 활성화 된다.
+     * @see FirebaseMessagingService#sendToToken(FcmMessage.FcmRequest, String)
+     * @see #isFcmTestTrue()
+     * @return false
+     * @author 정시원
+     */
+    @Profile({"dev", "test", "default"})
+    @Bean("isFcmTest")
     public boolean isFcmTestFalse(){
         return false;
     }

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -36,6 +36,14 @@ public class FirebaseMessagingService {
         log.info("Successfully sent FCM push notification: {}", response);
     }
 
+    /**
+     * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
+     * @param fcmMessage FCM메시지를 보내기 위한 DTO
+     * @param token FCM registration token 즉 FCM에서 발급한 기기의 토큰이다.
+     * @param isFcmTest 실제로 push알람을 보낼지 말지 여부 (해당 토큰의 유효성 검사만 진행)
+     * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
+     * @author 전지환, 정시원
+     */
     private String sendToToken(FcmMessage.FcmRequest fcmMessage, String token, boolean isFcmTest) throws FirebaseMessagingException {
         // FirebaseMessging으로 푸시알람을 보내기 위한 객체
         Message message = Message.builder()

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -3,6 +3,7 @@ package com.server.EZY.notification.service;
 import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.*;
 import com.server.EZY.notification.FcmMessage;
+import com.server.EZY.notification.config.FirebaseMessagingConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -16,6 +17,12 @@ import java.util.List;
 public class FirebaseMessagingService {
 
     private final FirebaseMessaging firebaseMessaging;
+    /**
+     * 해당 필드명은 Bean과 관련이 있으므로 변경하면 안된다!
+     * @see FirebaseMessagingConfig#isFcmTestTrue()
+     * @see FirebaseMessagingConfig#isFcmTestFalse()
+     */
+    private final boolean isFcmTest;
 
     /**
      * FCM registration token을 이용하여 해당 device에 알림을 전송한다.
@@ -24,7 +31,12 @@ public class FirebaseMessagingService {
      * @throws FirebaseMessagingException FCM 메시지 전송이 실패했을 경우 throw된다.
      * @author 전지환, 정시원
      */
-    public void sendToToken (FcmMessage.FcmRequest fcmMessage, String token) throws FirebaseMessagingException {
+    public void sendToToken(FcmMessage.FcmRequest fcmMessage, String token) throws FirebaseMessagingException {
+        String response = sendToToken(fcmMessage, token, isFcmTest);
+        log.info("Successfully sent FCM push notification: {}", response);
+    }
+
+    private String sendToToken(FcmMessage.FcmRequest fcmMessage, String token, boolean isFcmTest) throws FirebaseMessagingException {
         // FirebaseMessging으로 푸시알람을 보내기 위한 객체
         Message message = Message.builder()
                 .setNotification(
@@ -38,14 +50,13 @@ public class FirebaseMessagingService {
                                 .setAps(Aps.builder()
                                         .setSound("default")
                                         .build()
-                        ).build()
+                                ).build()
                 )
                 .setToken(token)
                 .putAllData(fcmMessage.getPayloads())
                 .build();
 
-        String response = firebaseMessaging.send(message);
-        log.info("Successfully sent message: {}", response);
+        return firebaseMessaging.send(message, isFcmTest);
     }
 
     /**

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,7 +8,7 @@ server:
 
 spring:
   profiles:
-    active: test_code
+    active: test_code # 테스트 코드 전용 profile 설정
 
   ### DB 설정 ###
   datasource:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,9 @@ server:
       force: true # UTF-8이 SpringBoot 2.x.x 에서는 기본이다.
 
 spring:
+  profiles:
+    active: test_code
+
   ### DB 설정 ###
   datasource:
     url: jdbc:h2:mem:EZY-database
@@ -61,3 +64,6 @@ sms:
   api:
     apikey: NCS7NY4SNRLQKWGE
     apiSecret: GE5VDUZPVLG9RB9QGDST4COFKC1UN7YJ
+
+fcm:
+  isTest: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,10 +7,8 @@ server:
       force: true # UTF-8이 SpringBoot 2.x.x 에서는 기본이다.
 
 spring:
-  config:
-    activate:
-      on-profile: test_code
-#      on-profile: default  # push알람을 실제로 전송되는지 확인하려면 해당 프로필 사용 혹은 dev, test도 사용가능합
+  profiles:
+    active: test_code
 
   ### DB 설정 ###
   datasource:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -64,6 +64,3 @@ sms:
   api:
     apikey: NCS7NY4SNRLQKWGE
     apiSecret: GE5VDUZPVLG9RB9QGDST4COFKC1UN7YJ
-
-fcm:
-  isTest: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,8 +7,10 @@ server:
       force: true # UTF-8이 SpringBoot 2.x.x 에서는 기본이다.
 
 spring:
-  profiles:
-    active: test_code
+  config:
+    activate:
+      on-profile: test_code
+#      on-profile: default  # push알람을 실제로 전송되는지 확인하려면 해당 프로필 사용 혹은 dev, test도 사용가능합
 
   ### DB 설정 ###
   datasource:


### PR DESCRIPTION
### 한 일
#### 1. 테스트 코드에서 push알람을 보내지 않고 테스트 하도록 변경
FCM에서 제공하는 dryrun을 통해 테스트 코드 실행시 push알람을 보내지 않고 테스트를 진행합니다.   
[공식문서 참고](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json)
![image](https://user-images.githubusercontent.com/62932968/140519621-d85763d7-1aa7-4a29-8e0d-b2489c828b5e.png)

테스트 코드를 실행 시 dryrun으로 push알람을 전송해야 하므로 테스트 코드 전용 profile를 이용해 해당 기능을 구현했습니다.

#### etc...
- `MessageConfiguration` 주석 보충

### 코드리뷰 원해요
- 명명규칙에 대한 피드백
- 더 좋은 로직 및 구조에 대한 피드백

### 앞으로 할 일
- 심부름 상태 로직 리펙터링
- FCM 비동기 처리
- push알람 실패시 지수 백오프를 이용한 재발송 기능 추가
