### PR TITLE
FCM push알람 비동기 처리 + 서버 시작시 Member더미 데이터 생성

### DIFF
--- a/src/main/java/com/server/EZY/dummy_for_dev/GenerateMemberAccount.java
+++ b/src/main/java/com/server/EZY/dummy_for_dev/GenerateMemberAccount.java
@@ -1,0 +1,86 @@
+package com.server.EZY.dummy_for_dev;
+
+import com.server.EZY.model.member.MemberEntity;
+import com.server.EZY.model.member.dto.MemberDto;
+import com.server.EZY.model.member.repository.MemberRepository;
+import com.server.EZY.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * dev, test 환경에서 테스팅을 위한 회원 더미데이터 생성하는 클래스
+ *
+ * @author 정시원
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@Profile({"dev", "test"})
+@Slf4j
+@RequiredArgsConstructor
+@Component
+class GenerateMemberAccount {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * Spring Boot 서버 실행 시점에 2021.11.7기준 server silo의 닉네임을 기준으로 회원을 생성후 AccessToken을 logging한다. <br>
+     * <ul>
+     *     <li>username : "siwony", "jyeonjyan", "qoxogus"</li>
+     *     <li>password : "12345678"</li>
+     * </ul>
+     * @author 정시원
+     */
+    @PostConstruct
+    private void createDummyMember(){
+        MemberEntity siwony = createMemberOfSiwony();
+        MemberEntity jyeonjyan = createMemberOfJyeonjyan();
+        MemberEntity qoxogus = createMemberOfQoxogus();
+
+        loggingAccessToken(siwony, jyeonjyan, qoxogus);
+    }
+
+    private void loggingAccessToken(MemberEntity...memberEntities){
+        log.info("\n=============================================================================== Access Token =================================================================================");
+        for (MemberEntity memberEntity: memberEntities)
+            log.info("{}: \"{}\"", memberEntity.getUsername(), jwtTokenProvider.createToken(memberEntity.getUsername(), memberEntity.getRoles()));
+
+        log.info("\n==============================================================================================================================================================================");
+    }
+    
+    private MemberEntity createMemberOfSiwony(){
+        MemberDto memberDto = MemberDto.builder()
+                .username("@siwony")
+                .password(passwordEncoder.encode("12345678"))
+                .phoneNumber("01000000000")
+                .fcmToken("cK_nm9tK3EdzgwOQXfjPbU:APA91bE-877ItvJsFelwTb23hntRort6v8fN-yGC8Mq1jzb8JEu3Qzi4oi7zJUKt6zigX02pjcQ84rwOQZjMngTdAkR6IKYygs-ZkGN94SNU6yY2MR8YqGvu2jLoPxQQ_f9pfQ8YdeZZ")
+                .build();
+        return memberRepository.save(memberDto.toEntity());
+    }
+
+    private MemberEntity createMemberOfJyeonjyan(){
+        MemberDto memberDto = MemberDto.builder()
+                .username("@jyeonjyan")
+                .password(passwordEncoder.encode("12345678"))
+                .phoneNumber("01000000001")
+                .fcmToken("eQb5CygpsUahmPBRDnTc0N:APA91bFaOlt2nZDJKJpO8dZsjS8vSDCZKxZWYBWtNXYUiIiUxLPiGTLcXuyuVTW1uqOxu55Ay9z_1ss-D2uz2xP-C_R2-5yxyV2pqn88zYts4WSxS4pgWgdvFtBAG6nU__dSYH7WW8Qk")
+                .build();
+        return memberRepository.save(memberDto.toEntity());
+    }
+
+    private MemberEntity createMemberOfQoxogus(){
+        MemberDto memberDto = MemberDto.builder()
+                .username("@qoxogus")
+                .password(passwordEncoder.encode("12345678"))
+                .phoneNumber("01000000002")
+                .fcmToken("fAp6e7Snyk_kg9ZxvTkt-a:APA91bEsOTGuuATRSKcHnwjqLL_aiT42BoLCuVJHrsW_JmvmfLqw8Ub2bZmUycR6qDyMbU2I41UScu9-kiv5bnI70wNRBXA1ku-IiEp5LiH_ZzGNBai7ZQqY5VGsb3s-BLu13iXEiISm")
+                .build();
+        return memberRepository.save(memberDto.toEntity());
+    }
+}

--- a/src/main/java/com/server/EZY/dummy_for_dev/GenerateMemberAccount.java
+++ b/src/main/java/com/server/EZY/dummy_for_dev/GenerateMemberAccount.java
@@ -49,7 +49,7 @@ class GenerateMemberAccount {
     private void loggingAccessToken(MemberEntity...memberEntities){
         log.info("\n=============================================================================== Access Token =================================================================================");
         for (MemberEntity memberEntity: memberEntities)
-            log.info("{}: \"{}\"", memberEntity.getUsername(), jwtTokenProvider.createToken(memberEntity.getUsername(), memberEntity.getRoles()));
+            log.info("{}: \"Bearer {}\"", memberEntity.getUsername(), jwtTokenProvider.createToken(memberEntity.getUsername(), memberEntity.getRoles()));
 
         log.info("\n==============================================================================================================================================================================");
     }

--- a/src/main/java/com/server/EZY/exception/fcm_push/FcmPushFailException.java
+++ b/src/main/java/com/server/EZY/exception/fcm_push/FcmPushFailException.java
@@ -1,0 +1,2 @@
+package com.server.EZY.exception.fcm_push;public class FcmPushFailException {
+}

--- a/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
+++ b/src/main/java/com/server/EZY/notification/service/FirebaseMessagingService.java
@@ -1,15 +1,20 @@
 package com.server.EZY.notification.service;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.firebase.messaging.*;
+import com.server.EZY.exception.fcm_push.FcmPushFailException;
 import com.server.EZY.notification.FcmMessage;
 import com.server.EZY.notification.config.FirebaseMessagingConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.Executors;
 
 @Service
 @RequiredArgsConstructor
@@ -126,7 +131,8 @@ public class FirebaseMessagingService {
      */
     @Async
     public ApiFuture<String> sendAsyncToToken(FcmMessage.FcmRequest fcmMessage, String fcmToken) {
-        return sendAsyncToToken(fcmMessage, fcmToken, false);
+        ApiFuture<String> apiFutureOfPushResult = sendAsyncToToken(fcmMessage, fcmToken, isFcmTest);
+        return apiFutureOfPushResult;
     }
 
     /**

--- a/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
+++ b/src/main/java/com/server/EZY/notification/service/feature/FcmActiveSender.java
@@ -27,7 +27,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getSender(), FcmActionSelector.ErrandAction.요청);
         // 실제로 push를 전송하는 구간
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
     }
 
     /**
@@ -41,7 +41,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.승인);
         // 실제로 push를 전송하는 구간
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**
@@ -55,7 +55,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.거절);
 
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**
@@ -68,7 +68,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandConfirmFcmMessageToRecipient(fcmSourceDto, FcmActionSelector.ErrandAction.완료);
 
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
     }
 
     /**
@@ -81,7 +81,7 @@ public class FcmActiveSender {
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandConfirmFcmMessageToRecipient(fcmSourceDto, FcmActionSelector.ErrandAction.실패);
 
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getRecipient()));
     }
 
     /**
@@ -94,7 +94,7 @@ public class FcmActiveSender {
     public void sendGiveUpErrandFcmToSender(FcmSourceDto fcmSourceDto) throws FirebaseMessagingException{
         FcmMessage.FcmRequest request =
                 fcmMakerService.makeErrandFcmMessage(fcmSourceDto, fcmSourceDto.getRecipient(), FcmActionSelector.ErrandAction.포기);
-        firebaseMessagingService.sendToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
+        firebaseMessagingService.sendAsyncToToken(request, findFcmTokenByUsername(fcmSourceDto.getSender()));
     }
 
     /**


### PR DESCRIPTION
## 한 일
#### 1. FCM push알람 비동기 처리
`FirebaseMessaging`에서 제공하는 `sendAsync`함수를 이용해 send합니다.

#### 2. application 시작시 Member더미 데이터 생성
server silo의 github를 기준으로 3개의 회원 계정을 생성했습니다. 이는 dev, test 프로필에서만 실행됩니다.
![image](https://user-images.githubusercontent.com/62932968/140634699-e105d90a-2341-4b94-b9ad-8ad787e9df3b.png)


### 코드리뷰 원해요
- 명명규칙에 대한 피드백
- 더 나은 로직에 대한 피드백

### 앞으로 할 일
#### 1. push 알람 실패 시 retry전략 구현
push알람 실패 시 재전송하는 기능을 구현할 예정입니다.