### PR TITLE
ErrandEntity ERD에 없는 필드 제거

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
@@ -26,8 +26,6 @@ public class ErrandEntity extends PlanEntity {
     @ManyToOne @JoinColumn(name = "errand_status_id", nullable = false, updatable = false)
     private ErrandDetailEntity errandDetailEntity;
 
-    private String location;
-
     /**
      * 심부름을 추가하는 생성자
      * @param memberEntity 연관관계를 맻을 유저엔티티

--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
@@ -5,10 +5,7 @@ import com.server.EZY.model.plan.PlanEntity;
 import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
 import com.server.EZY.model.plan.tag.TagEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -61,16 +58,12 @@ public class ErrandEntity extends PlanEntity {
      * @return planIdx가 null이고 memberEntity가 변경되어 clone된 ErrandEntity
      * @author 정시원
      */
+    @SneakyThrows // Exception을 무시하기 위한 annotation
     public ErrandEntity cloneToMemberEntity(MemberEntity memberEntity){
-        ErrandEntity clonedErrandEntity = ErrandEntity.builder()
-                .memberEntity(memberEntity)
-                .tagEntity(null)
-                .planInfo(planInfo)
-                .period(period)
-                .errandDetailEntity(errandDetailEntity)
-                .location(location)
-                .build();
-        clonedErrandEntity.setPlanIdx(null);
+        ErrandEntity clonedErrandEntity = (ErrandEntity) clone();
+        clonedErrandEntity.planIdx = null;
+        clonedErrandEntity.memberEntity = memberEntity;
+
         return clonedErrandEntity;
     }
 

--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
@@ -5,7 +5,10 @@ import com.server.EZY.model.plan.PlanEntity;
 import com.server.EZY.model.plan.embedded_type.Period;
 import com.server.EZY.model.plan.embedded_type.PlanInfo;
 import com.server.EZY.model.plan.tag.TagEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
@@ -40,7 +43,6 @@ public class ErrandEntity extends PlanEntity {
     public ErrandEntity(MemberEntity memberEntity, TagEntity tagEntity, PlanInfo planInfo, Period period, ErrandDetailEntity errandDetailEntity, String location){
         super(memberEntity, tagEntity, planInfo, period);
         this.errandDetailEntity = errandDetailEntity;
-        this.location = location;
     }
 
     /**
@@ -56,12 +58,15 @@ public class ErrandEntity extends PlanEntity {
      * @return planIdx가 null이고 memberEntity가 변경되어 clone된 ErrandEntity
      * @author 정시원
      */
-    @SneakyThrows // Exception을 무시하기 위한 annotation
     public ErrandEntity cloneToMemberEntity(MemberEntity memberEntity){
-        ErrandEntity clonedErrandEntity = (ErrandEntity) clone();
+        ErrandEntity clonedErrandEntity = ErrandEntity.builder()
+                .memberEntity(memberEntity)
+                .tagEntity(null)
+                .planInfo(planInfo)
+                .period(period)
+                .errandDetailEntity(errandDetailEntity)
+                .build();
         clonedErrandEntity.planIdx = null;
-        clonedErrandEntity.memberEntity = memberEntity;
-
         return clonedErrandEntity;
     }
 

--- a/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/ErrandEntity.java
@@ -62,20 +62,11 @@ public class ErrandEntity extends PlanEntity {
         ErrandEntity clonedErrandEntity = ErrandEntity.builder()
                 .memberEntity(memberEntity)
                 .tagEntity(null)
-                .planInfo(planInfo)
-                .period(period)
-                .errandDetailEntity(errandDetailEntity)
+                .planInfo(this.planInfo)
+                .period(this.period)
+                .errandDetailEntity(this.errandDetailEntity)
                 .build();
         clonedErrandEntity.planIdx = null;
         return clonedErrandEntity;
-    }
-
-    /**
-     * planIdx에 대한 setter
-     * @param planIdx
-     * @author 정시원
-     */
-    private void setPlanIdx(Long planIdx){
-        this.planIdx = planIdx;
     }
 }

--- a/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/ErrandTest.java
@@ -108,8 +108,8 @@ class ErrandTest {
         assertEquals(period, savedSiwonErrandEntity.getPeriod());
         assertEquals(savedSiwonErrandEntity.getPeriod(), jihwanErrand.getPeriod());
 
-        assertNull(savedSiwonErrandEntity.getLocation()); // location를 저장안했기 때문에 null
-        assertEquals(savedSiwonErrandEntity.getLocation(), savedJihwanErrandEntity.getLocation());
+        assertNull(savedSiwonErrandEntity.getPlanInfo().getLocation()); // location를 저장안했기 때문에 null
+        assertEquals(savedSiwonErrandEntity.getPlanInfo().getLocation(), savedJihwanErrandEntity.getPlanInfo().getLocation());
     }
 
     @Test @DisplayName("심부름 삭제 테스트")

--- a/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
+++ b/src/test/java/com/server/EZY/model/plan/errand/service/ErrandStatusCycleTest.java
@@ -120,7 +120,7 @@ public class ErrandStatusCycleTest {
         assertNotEquals(senderErrandEntity.getMemberEntity(), recipientErrandEntity.getMemberEntity());
         assertEquals(senderErrandEntity.getPlanInfo(), recipientErrandEntity.getPlanInfo());
         assertEquals(senderErrandEntity.getPeriod(), recipientErrandEntity.getPeriod());
-        assertEquals(senderErrandEntity.getLocation(), recipientErrandEntity.getLocation());
+        assertEquals(senderErrandEntity.getPlanInfo().getLocation(), recipientErrandEntity.getPlanInfo().getLocation());
 
         assertEquals(senderErrandDetailEntity.getErrandDetailIdx(), recipientErrandDetailEntity.getErrandDetailIdx());
         assertEquals(senderErrandDetailEntity.getSenderIdx(), recipientErrandDetailEntity.getSenderIdx());


### PR DESCRIPTION
### 한 일
1. ErrandEntity에 location이 ERD에 없으므로 제거합니다.
  > `location`은 `PlalnEntity.PlanInfo`에 있으므로 중복이 발생했습니다.
