### PR TITLE
Feature/personalplan query

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -21,6 +21,13 @@ public class PersonalPlanController {
     private final PersonalPlanService personalPlanService;
     private final ResponseService responseService;
 
+    /**
+     * 개인 일정을 추가하는 controller.
+     *
+     * @param personalPlanSetDto
+     * @return getSuccessResult or NOT
+     * @author 전지환
+     */
     @PostMapping
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
@@ -31,12 +38,21 @@ public class PersonalPlanController {
         return responseService.getSuccessResult();
     }
 
+    /**
+     * 기간별 개인 일정을 조회하는 controller.
+     *
+     * @param startDateOrNull
+     * @param endDateOrNull
+     * @return ListResult
+     * @author 전지환
+     */
     @GetMapping
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult getAllPersonalPlan(
+            // TODO Exception Handling
             @RequestParam(value = "startDate", required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDateOrNull,
             @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDateOrNull
     ){

--- a/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/controller/PersonalPlanController.java
@@ -72,6 +72,13 @@ public class PersonalPlanController {
         }
     }
 
+    /**
+     * 개인 일정 단건 조회하는 controller.
+     *
+     * @param planIdx
+     * @return getSingleResult
+     * @author 전지환
+     */
     @GetMapping("/{planIdx}")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
@@ -81,6 +88,15 @@ public class PersonalPlanController {
         return responseService.getSingleResult(personalPlanService.getThisPersonalPlan(planIdx));
     }
 
+    /**
+     * 특정 개인 일정을 수정하는 controller.
+     *
+     * @param planIdx
+     * @param personalPlanSetDto
+     * @return getSuccessResult
+     * @throws Exception
+     * @author 전지환
+     */
     @PutMapping("/{planIdx}")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
@@ -92,6 +108,13 @@ public class PersonalPlanController {
     }
 
 
+    /**
+     * 특정 개인 일정을 삭제하는 controller.
+     *
+     * @param planIdx
+     * @return getSuccessResult
+     * @author 전지환
+     */
     @DeleteMapping("/{planIdx}")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),

--- a/src/main/java/com/server/EZY/model/plan/personal/dto/PersonalPlanDto.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/dto/PersonalPlanDto.java
@@ -99,7 +99,7 @@ public class PersonalPlanDto {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class PersonalPlanListDto {
-        private Long personalPlanIdx;
+        private Long planIdx;
         private PlanInfo planInfo;
         private Period period;
         private Long tagIdx;
@@ -108,8 +108,8 @@ public class PersonalPlanDto {
         private Boolean repetition;
 
         @QueryProjection
-        public PersonalPlanListDto(Long personalPlanIdx, PlanInfo planInfo, Period period, Long tagIdx, String tag, Color color, Boolean repetition) {
-            this.personalPlanIdx = personalPlanIdx;
+        public PersonalPlanListDto(Long planIdx, PlanInfo planInfo, Period period, Long tagIdx, String tag, Color color, Boolean repetition) {
+            this.planIdx = planIdx;
             this.planInfo = planInfo;
             this.period = period;
             this.tagIdx = tagIdx;

--- a/src/main/java/com/server/EZY/model/plan/personal/dto/PersonalPlanDto.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/dto/PersonalPlanDto.java
@@ -88,4 +88,34 @@ public class PersonalPlanDto {
             this.repetition = repetition;
         }
     }
+
+    /**
+     * 모든 개인일정을 조회할 때 사용되는 dto 입니다.
+     *
+     * @since 1
+     * @version 1
+     * @author 전지환
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PersonalPlanListDto {
+        private Long personalPlanIdx;
+        private PlanInfo planInfo;
+        private Period period;
+        private Long tagIdx;
+        private String tag;
+        private Color color;
+        private Boolean repetition;
+
+        @QueryProjection
+        public PersonalPlanListDto(Long personalPlanIdx, PlanInfo planInfo, Period period, Long tagIdx, String tag, Color color, Boolean repetition) {
+            this.personalPlanIdx = personalPlanIdx;
+            this.planInfo = planInfo;
+            this.period = period;
+            this.tagIdx = tagIdx;
+            this.tag = tag;
+            this.color = color;
+            this.repetition = repetition;
+        }
+    }
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface PersonalPlanCustomRepository {
     List<PersonalPlanDto.PersonalPlanListDto> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
-    List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<PersonalPlanEntity> findPersonalPlansBetweenDate(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
     PersonalPlanDto.PersonalPlanDetails findPersonalPlanDetailsByPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface PersonalPlanCustomRepository {
     List<PersonalPlanDto.PersonalPlanListDto> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
-    List<PersonalPlanEntity> findPersonalPlansBetweenDate(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<PersonalPlanDto.PersonalPlanListDto> findPersonalPlansBetweenDate(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
     PersonalPlanDto.PersonalPlanDetails findPersonalPlanDetailsByPlanIdx(MemberEntity memberEntity, Long planIdx);
 }

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepository.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PersonalPlanCustomRepository {
-    List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
+    List<PersonalPlanDto.PersonalPlanListDto> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity);
     List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime);
     PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx);
     PersonalPlanDto.PersonalPlanDetails findPersonalPlanDetailsByPlanIdx(MemberEntity memberEntity, Long planIdx);

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.server.EZY.model.member.MemberEntity;
 import com.server.EZY.model.plan.personal.PersonalPlanEntity;
 import com.server.EZY.model.plan.personal.dto.PersonalPlanDto;
 import com.server.EZY.model.plan.personal.dto.QPersonalPlanDto_PersonalPlanDetails;
+import com.server.EZY.model.plan.personal.dto.QPersonalPlanDto_PersonalPlanListDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,11 +28,29 @@ public class PersonalPlanCustomRepositoryImpl implements PersonalPlanCustomRepos
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    /**
+     * 모든 개인일정을 조회하는 쿼리 메소드.
+     *
+     * @param memberEntity
+     * @return List<PersonalPlanDto.PersonalPlanListDto>
+     * @author 전지환
+     */
     @Override
-    public List<PersonalPlanEntity> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity) {
+    public List<PersonalPlanDto.PersonalPlanListDto> findAllPersonalPlanByMemberEntity(MemberEntity memberEntity) {
         return jpaQueryFactory
-                .selectFrom(personalPlanEntity)
-                .where(personalPlanEntity.memberEntity.eq(memberEntity)).fetch();
+                .select(new QPersonalPlanDto_PersonalPlanListDto(
+                        personalPlanEntity.planIdx,
+                        personalPlanEntity.planInfo,
+                        personalPlanEntity.period,
+                        personalPlanEntity.tagEntity.tagIdx,
+                        personalPlanEntity.tagEntity.tag,
+                        personalPlanEntity.tagEntity.color,
+                        personalPlanEntity.repetition
+                ))
+                .from(personalPlanEntity)
+                .leftJoin(personalPlanEntity.tagEntity, tagEntity)
+                .where(personalPlanEntity.memberEntity.eq(memberEntity))
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
@@ -29,6 +29,24 @@ public class PersonalPlanCustomRepositoryImpl implements PersonalPlanCustomRepos
     private final JPAQueryFactory jpaQueryFactory;
 
     /**
+     * personalPlanEntity를 가져야 하는 전략 메소드에서 사용하는 쿼리 메소드
+     *
+     * @param memberEntity
+     * @param planIdx
+     * @return PersonalPlanEntity
+     * @author 전지환
+     */
+    @Override
+    public PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx) {
+        return jpaQueryFactory
+                .selectFrom(personalPlanEntity)
+                .where(
+                        personalPlanEntity.memberEntity.eq(memberEntity),
+                        personalPlanEntity.planIdx.eq(planIdx)
+                ).fetchOne();
+    }
+
+    /**
      * 모든 개인일정을 조회하는 쿼리 메소드.
      *
      * @param memberEntity
@@ -82,16 +100,6 @@ public class PersonalPlanCustomRepositoryImpl implements PersonalPlanCustomRepos
                         personalPlanEntity.memberEntity.eq(memberEntity),
                         personalPlanEntity.period.startDateTime.between(startDateTime, endDateTime)
                 ).fetch();
-    }
-
-    @Override
-    public PersonalPlanEntity findThisPersonalPlanByMemberEntityAndPlanIdx(MemberEntity memberEntity, Long planIdx) {
-        return jpaQueryFactory
-                .selectFrom(personalPlanEntity)
-                .where(
-                        personalPlanEntity.memberEntity.eq(memberEntity),
-                        personalPlanEntity.planIdx.eq(planIdx)
-                ).fetchOne();
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
@@ -63,11 +63,21 @@ public class PersonalPlanCustomRepositoryImpl implements PersonalPlanCustomRepos
      * @author 전지환
      */
     @Override
-    public List<PersonalPlanEntity> findPersonalPlansBetweenDate(
+    public List<PersonalPlanDto.PersonalPlanListDto> findPersonalPlansBetweenDate(
             MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime
     ) {
         return jpaQueryFactory
-                .selectFrom(personalPlanEntity)
+                .select(new QPersonalPlanDto_PersonalPlanListDto(
+                        personalPlanEntity.planIdx,
+                        personalPlanEntity.planInfo,
+                        personalPlanEntity.period,
+                        personalPlanEntity.tagEntity.tagIdx,
+                        personalPlanEntity.tagEntity.tag,
+                        personalPlanEntity.tagEntity.color,
+                        personalPlanEntity.repetition
+                ))
+                .from(personalPlanEntity)
+                .leftJoin(personalPlanEntity.tagEntity, tagEntity)
                 .where(
                         personalPlanEntity.memberEntity.eq(memberEntity),
                         personalPlanEntity.period.startDateTime.between(startDateTime, endDateTime)

--- a/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/repository/PersonalPlanCustomRepositoryImpl.java
@@ -53,9 +53,19 @@ public class PersonalPlanCustomRepositoryImpl implements PersonalPlanCustomRepos
                 .fetch();
     }
 
+    /**
+     * 기간 내의 개인일정(들)을 조회하는 쿼리 메소드.
+     *
+     * @param memberEntity
+     * @param startDateTime
+     * @param endDateTime
+     * @return
+     * @author 전지환
+     */
     @Override
-    public List<PersonalPlanEntity> findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
-            MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public List<PersonalPlanEntity> findPersonalPlansBetweenDate(
+            MemberEntity memberEntity, LocalDateTime startDateTime, LocalDateTime endDateTime
+    ) {
         return jpaQueryFactory
                 .selectFrom(personalPlanEntity)
                 .where(

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface PersonalPlanService {
     PersonalPlanEntity createPersonalPlan(PersonalPlanDto.PersonalPlanSet personalPlanSetDto);
-    List<PersonalPlanEntity> getAllPersonalPlan();
+    List<PersonalPlanDto.PersonalPlanListDto> getAllPersonalPlan();
     List<PersonalPlanEntity> getThisDatePersonalPlanEntities(LocalDate startDate);
     List<PersonalPlanEntity> getPersonalPlanEntitiesBetween(LocalDate startDate, LocalDate endDate);
     PersonalPlanDto.PersonalPlanDetails getThisPersonalPlan(Long planIdx);

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanService.java
@@ -9,8 +9,8 @@ import java.util.List;
 public interface PersonalPlanService {
     PersonalPlanEntity createPersonalPlan(PersonalPlanDto.PersonalPlanSet personalPlanSetDto);
     List<PersonalPlanDto.PersonalPlanListDto> getAllPersonalPlan();
-    List<PersonalPlanEntity> getThisDatePersonalPlanEntities(LocalDate startDate);
-    List<PersonalPlanEntity> getPersonalPlanEntitiesBetween(LocalDate startDate, LocalDate endDate);
+    List<PersonalPlanDto.PersonalPlanListDto> getThisDatePersonalPlanEntities(LocalDate startDate);
+    List<PersonalPlanDto.PersonalPlanListDto> getPersonalPlanEntitiesBetween(LocalDate startDate, LocalDate endDate);
     PersonalPlanDto.PersonalPlanDetails getThisPersonalPlan(Long planIdx);
     void deleteThisPersonalPlan(Long planIdx);
     PersonalPlanEntity updateThisPersonalPlan(Long planIdx, PersonalPlanDto.PersonalPlanSet personalPlanSetDto) throws Exception;

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -44,11 +44,12 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
 
     /**
      * 내 전체 personalPlan을 "조회"하기 위해 사용되는 비즈니스 로직입니다.
+     *
      * @return List<PersonalPlanEntity>
      * @author 전지환
      */
     @Override
-    public List<PersonalPlanEntity> getAllPersonalPlan() {
+    public List<PersonalPlanDto.PersonalPlanListDto> getAllPersonalPlan() {
         MemberEntity currentUser = userUtil.getCurrentUser();
         return personalPlanRepository.findAllPersonalPlanByMemberEntity(currentUser);
     }

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -56,33 +56,37 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
 
     /**
      * 해당 Date 에 수행(start) 되는 개인일정을 모두 "조회"하기 위해 사용되는 비즈니스 로직입니다.
+     *
      * @param startDate
      * @return List<PersonalPlanEntity>
      * @author 전지환
      */
     @Override
-    public List<PersonalPlanEntity> getThisDatePersonalPlanEntities(LocalDate startDate) {
+    public List<PersonalPlanDto.PersonalPlanListDto> getThisDatePersonalPlanEntities(LocalDate startDate) {
         MemberEntity currentUser = userUtil.getCurrentUser();
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is startDate atEndOfDay: {}==========", startDate.atTime(LocalTime.MAX));
         return personalPlanRepository.findPersonalPlansBetweenDate(
-                currentUser, startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX));
+                currentUser, startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX)
+        );
     }
 
     /**
      * startDate 와 endDate 기간내에 수행(start) 되는 개인일정을 모두 "조회"하기 위해 사용되는 비즈니스 로직입니다.
+     *
      * @param startDate
      * @param endDate
      * @return List<PersonalPlanEntity>
      * @author 전지환
      */
     @Override
-    public List<PersonalPlanEntity> getPersonalPlanEntitiesBetween(LocalDate startDate, LocalDate endDate) {
+    public List<PersonalPlanDto.PersonalPlanListDto> getPersonalPlanEntitiesBetween(LocalDate startDate, LocalDate endDate) {
         MemberEntity currentUser = userUtil.getCurrentUser();
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is endDate atEndOfDay: {}==========", endDate.atTime(LocalTime.MAX));
         return personalPlanRepository.findPersonalPlansBetweenDate(
-                currentUser, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
+                currentUser, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)
+        );
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -65,7 +65,7 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
         MemberEntity currentUser = userUtil.getCurrentUser();
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is startDate atEndOfDay: {}==========", startDate.atTime(LocalTime.MAX));
-        return personalPlanRepository.findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
+        return personalPlanRepository.findPersonalPlansBetweenDate(
                 currentUser, startDate.atStartOfDay(), startDate.atTime(LocalTime.MAX));
     }
 
@@ -81,7 +81,7 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
         MemberEntity currentUser = userUtil.getCurrentUser();
         log.debug("====== this is startDate atStartOfDay: {}==========", startDate.atStartOfDay());
         log.debug("====== this is endDate atEndOfDay: {}==========", endDate.atTime(LocalTime.MAX));
-        return personalPlanRepository.findPersonalPlanEntitiesByMemberEntityAndPeriod_StartDateTimeBetween(
+        return personalPlanRepository.findPersonalPlansBetweenDate(
                 currentUser, startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
     }
 

--- a/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImpl.java
@@ -17,6 +17,11 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+/**
+ * @version 1
+ * @since 1
+ * @author 전지환
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -103,6 +108,7 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
 
     /**
      * 내가 지정한 personalPlan을 업데이트 하는 비즈니스 로직입니다.
+     *
      * @param planIdx
      * @param personalPlan
      * @return PersonalPlanEntity
@@ -124,6 +130,7 @@ public class PersonalPlanServiceImpl implements PersonalPlanService{
 
     /**
      * 내가 지정한 personalPlan을 삭제하는 비즈니스 로직입니다.
+     *
      * @param planIdx
      * @author 전지환
      */

--- a/src/main/java/com/server/EZY/model/plan/personal/service/strategy/PersonalPlanStrategyImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/personal/service/strategy/PersonalPlanStrategyImpl.java
@@ -6,11 +6,23 @@ import com.server.EZY.model.plan.personal.repository.PersonalPlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * @version 1
+ * @since 1
+ * @author 전지환
+ */
 @Service
 @RequiredArgsConstructor
 public class PersonalPlanStrategyImpl implements PersonalPlanStrategy{
     private final PersonalPlanRepository personalPlanRepository;
 
+    /**
+     * 개인일정 단건을 personalPlanEntity로 반환하는 전략 메소드.
+     *
+     * @param memberEntity
+     * @param planIdx
+     * @return PersonalPlanEntity
+     */
     @Override
     public PersonalPlanEntity singlePersonalPlanCheck(MemberEntity memberEntity, Long planIdx) {
         return personalPlanRepository.findThisPersonalPlanByMemberEntityAndPlanIdx(memberEntity, planIdx);

--- a/src/test/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImplTest.java
@@ -252,7 +252,7 @@ class PersonalPlanServiceImplTest {
         List<PersonalPlanEntity> personalPlanEntityList = personalPlanRepository.saveAll(wannaFindPersonalPlanEntities);
         personalPlanRepository.saveAll(anotherPersonalPlanEntities);
 
-        List<PersonalPlanEntity> thisDatePersonalPlanEntities = personalPlanService.getThisDatePersonalPlanEntities(LocalDate.of(2021, 7, 24));
+        List<PersonalPlanDto.PersonalPlanListDto> thisDatePersonalPlanEntities = personalPlanService.getThisDatePersonalPlanEntities(LocalDate.of(2021, 7, 24));
 
         //Then
         assertEquals(personalPlanEntityList.size(), thisDatePersonalPlanEntities.size());
@@ -290,7 +290,7 @@ class PersonalPlanServiceImplTest {
         List<PersonalPlanEntity> personalPlanEntityList1 = personalPlanRepository.saveAll(wannaFindPersonalPlanEntities);
         List<PersonalPlanEntity> personalPlanEntityList2 = personalPlanRepository.saveAll(anotherPersonalPlanEntities);
 
-        List<PersonalPlanEntity> personalPlanEntitiesBetween = personalPlanService.getPersonalPlanEntitiesBetween(
+        List<PersonalPlanDto.PersonalPlanListDto> personalPlanEntitiesBetween = personalPlanService.getPersonalPlanEntitiesBetween(
                 LocalDate.of(2021, 7, 21), LocalDate.of(2021, 7, 25));
 
         //Then

--- a/src/test/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImplTest.java
+++ b/src/test/java/com/server/EZY/model/plan/personal/service/PersonalPlanServiceImplTest.java
@@ -113,7 +113,7 @@ class PersonalPlanServiceImplTest {
 
         // When
         personalPlanRepository.saveAll(personalPlanEntities);
-        List<PersonalPlanEntity> allPersonalPlan = personalPlanService.getAllPersonalPlan();
+        List<PersonalPlanDto.PersonalPlanListDto> allPersonalPlan = personalPlanService.getAllPersonalPlan();
 
         // then
         assertTrue(allPersonalPlan.size() == 5);


### PR DESCRIPTION
## 개요
모든 개인일정 query 메소드 return 을 Dto로 바꾸었습니다.
(Entity return 예외) delete, put 에 사용하는 `singlePersonalPlanCheck.java` 전략 메소드에 필요한 쿼리 메소드. 

![image](https://user-images.githubusercontent.com/67095821/141393122-dad88042-46d6-4e5d-ac09-fb4620f2f584.png)


## TODO
* Exception Handling
* api 문서 수정
* test coverage