### PR TITLE
NonUniqueResultException 해결

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/errand/repository/errand/ErrandCustomRepositoryImpl.java
+++ b/src/main/java/com/server/EZY/model/plan/errand/repository/errand/ErrandCustomRepositoryImpl.java
@@ -28,6 +28,7 @@ public class ErrandCustomRepositoryImpl implements ErrandCustomRepository {
     public Optional<ErrandEntity> findWithErrandStatusByErrandIdx(long errandIdx) {
         ErrandEntity errand = (ErrandEntity) queryFactory
                 .from(errandEntity)
+                .where(errandEntity.planIdx.eq(errandIdx))
                 .join(errandEntity.errandDetailEntity, errandDetailEntity)
                 .fetchJoin()
                 .fetchOne();


### PR DESCRIPTION
## 개요
`NonUniqueResultException` 발생하던 오류 해결
![image](https://user-images.githubusercontent.com/62932968/142145069-853fbe10-50b0-4606-9fbe-63dfcdda99be.png)

## 원인
1. where절 누락
   > `.where(errandEntity.planIdx.eq(errandIdx))`