### PR TITLE
태그 저장시 tagIdx반환

### DIFF
--- a/src/main/java/com/server/EZY/model/plan/tag/controller/TagController.java
+++ b/src/main/java/com/server/EZY/model/plan/tag/controller/TagController.java
@@ -23,7 +23,8 @@ public class TagController {
      * 태그를 추가하는 Controller
      * @param tagSetDto
      * @return getSuccessResult
-     * @author 전지환, 배태현
+     * @author 전지환, 정시원
+     * @return TagGetDto.TagIdx - tagIdx를 반환하는 객체
      */
     @PostMapping("")
     @ApiImplicitParams({

--- a/src/main/java/com/server/EZY/model/plan/tag/controller/TagController.java
+++ b/src/main/java/com/server/EZY/model/plan/tag/controller/TagController.java
@@ -1,5 +1,7 @@
 package com.server.EZY.model.plan.tag.controller;
 
+import com.server.EZY.model.plan.tag.TagEntity;
+import com.server.EZY.model.plan.tag.dto.TagGetDto;
 import com.server.EZY.model.plan.tag.dto.TagSetDto;
 import com.server.EZY.model.plan.tag.service.TagService;
 import com.server.EZY.response.ResponseService;
@@ -29,8 +31,8 @@ public class TagController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult addTag(@RequestBody TagSetDto tagSetDto) {
-        tagService.saveTag(tagSetDto);
-        return responseService.getSuccessResult();
+        TagEntity savedTagEntity = tagService.saveTag(tagSetDto);
+        return responseService.getSingleResult(new TagGetDto.TagIdx(savedTagEntity.getTagIdx()));
     }
 
     /**

--- a/src/main/java/com/server/EZY/model/plan/tag/dto/TagGetDto.java
+++ b/src/main/java/com/server/EZY/model/plan/tag/dto/TagGetDto.java
@@ -9,4 +9,17 @@ public class TagGetDto {
     private Long tagIdx;
     private String tag;
     private Color color;
+
+    /**
+     * tagIdx를 반환하기 위한 class
+     *
+     * @author 정시원
+     * @version 1.0.0
+     * @since 1.0.0
+     */
+    @Getter @Setter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE) @AllArgsConstructor
+    public static class TagIdx{
+        long tagIdx;
+    }
 }

--- a/src/main/java/com/server/EZY/model/plan/tag/dto/TagGetDto.java
+++ b/src/main/java/com/server/EZY/model/plan/tag/dto/TagGetDto.java
@@ -17,7 +17,7 @@ public class TagGetDto {
      * @version 1.0.0
      * @since 1.0.0
      */
-    @Getter @Setter
+    @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE) @AllArgsConstructor
     public static class TagIdx{
         long tagIdx;


### PR DESCRIPTION
## 개요
태그 저장시 저장된 tagIdx반환이 필요해 해당 기능 추가

![image](https://user-images.githubusercontent.com/62932968/142202688-1422f034-3d7a-4105-8c2c-3e3412fb4dc6.png)

다음과 같이 반환합니다. 자세한 사항은 노션의 `[POST] 태그 추가:  /v1/tag` 에서 확인해주세요
<img width=350 src="https://user-images.githubusercontent.com/62932968/142202836-7aaac4c4-9138-48f6-9d2a-21071062d8ea.png">
